### PR TITLE
Improve landing page styling

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,41 @@ body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 0;
+  background-color: #fff;
+}
+
+.container {
+  padding: 2rem;
+}
+
+.header {
+  font-size: 2rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  color: #16a34a;
+}
+
+.btn {
+  background-color: #16a34a;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn:hover {
+  background-color: #15803d;
+}
+
+textarea.url-box {
+  width: 100%;
+  max-width: 500px;
+  min-height: 60px;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  resize: none;
 }
 
 button:disabled {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,28 +1,29 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 const Home: React.FC = () => {
   const [loading, setLoading] = useState(false);
-  const navigate = useNavigate();
+  const [endpointUrl, setEndpointUrl] = useState('');
 
   const createEndpoint = async () => {
     setLoading(true);
     const res = await fetch('/api/endpoints', { method: 'POST' });
     const data = await res.json();
     setLoading(false);
-    navigate(`/endpoint/${data.uuid}`);
+    setEndpointUrl(`${window.location.origin}/endpoint/${data.uuid}`);
   };
 
   return (
-    <div className="p-8 space-y-4 font-sans">
-      <h1 className="text-3xl font-semibold">WebhookMirror</h1>
-      <p className="text-gray-600">Generate a unique capture URL to inspect webhook payloads.</p>
-      <button
-        onClick={createEndpoint}
-        disabled={loading}
-        className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded flex items-center space-x-2"
-      >
-        {loading && <span className="loading-spinner" />}<span>{loading ? 'Creating...' : 'Create endpoint'}</span>
+    <div className="container">
+      <h1 className="header">Webhook Mirror</h1>
+      <p>Generate a unique capture URL to inspect webhook payloads.</p>
+      <textarea
+        className="url-box"
+        readOnly
+        value={endpointUrl}
+        placeholder="Click 'Generate URL' to create an endpoint"
+      />
+      <button onClick={createEndpoint} disabled={loading} className="btn">
+        {loading && <span className="loading-spinner" />} {loading ? 'Creating...' : 'Generate URL'}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- add simple styling and green button
- show generated endpoint URL in a textarea
- make landing page background white

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d0d8e6a28832c80471e24c27080ff