### PR TITLE
Fix create endpoint flow and show API response

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,6 +7,9 @@ body {
 
 .container {
   padding: 2rem;
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: center;
 }
 
 .header {
@@ -42,6 +45,22 @@ textarea.url-box {
 button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.status {
+  margin-top: 1rem;
+  text-align: left;
+  background-color: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  padding: 0.5rem;
+  border-radius: 4px;
+}
+
+.headers {
+  background-color: #e5e7eb;
+  padding: 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
 }
 .loading-spinner {
   border: 2px solid rgba(255, 255, 255, 0.3);

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,13 +3,28 @@ import React, { useState } from 'react';
 const Home: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [endpointUrl, setEndpointUrl] = useState('');
+  const [apiStatus, setApiStatus] = useState<string | null>(null);
+  const [apiHeaders, setApiHeaders] = useState<Record<string, string> | null>(null);
 
   const createEndpoint = async () => {
     setLoading(true);
-    const res = await fetch('/api/endpoints', { method: 'POST' });
-    const data = await res.json();
-    setLoading(false);
-    setEndpointUrl(`${window.location.origin}/endpoint/${data.uuid}`);
+    setApiStatus(null);
+    setApiHeaders(null);
+    try {
+      const res = await fetch('/api/endpoints', { method: 'POST' });
+      const data = await res.json();
+      setEndpointUrl(`${window.location.origin}/endpoint/${data.uuid}`);
+      setApiStatus(`Success: ${res.status}`);
+      const headersObj: Record<string, string> = {};
+      res.headers.forEach((v, k) => {
+        headersObj[k] = v;
+      });
+      setApiHeaders(headersObj);
+    } catch (err) {
+      setApiStatus('Error creating endpoint');
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -25,6 +40,14 @@ const Home: React.FC = () => {
       <button onClick={createEndpoint} disabled={loading} className="btn">
         {loading && <span className="loading-spinner" />} {loading ? 'Creating...' : 'Generate URL'}
       </button>
+      {apiStatus && (
+        <div className="status">
+          <p>{apiStatus}</p>
+          {apiHeaders && (
+            <pre className="headers">{JSON.stringify(apiHeaders, null, 2)}</pre>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,4 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- show API call status and headers when creating an endpoint
- center layout styles and status panel
- proxy `/api` calls to Rails backend in Vite dev server

## Testing
- `npm --prefix frontend run build`
- `bundle exec rails test`


------
https://chatgpt.com/codex/tasks/task_e_686d0f17b7b4832c970c0f34e98d65f0