### PR TITLE
Add request viewer redirect and improve UI

### DIFF
--- a/backend/app/controllers/capture_controller.rb
+++ b/backend/app/controllers/capture_controller.rb
@@ -6,6 +6,11 @@ class CaptureController < ActionController::API
       headers: request.headers.to_h.select { |k, _| k.start_with?("HTTP_") },
       body: request.raw_post
     )
+
+    if request.get? && request.headers["Accept"].to_s.include?("text/html")
+      redirect_to "#{request.base_url}/endpoint/#{endpoint.uuid}" and return
+    end
+
     render json: { id: req.id }
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   namespace :api do
-    get 'endpoints/by_uuid/:uuid', to: 'endpoints#show_by_uuid'
+    get "endpoints/by_uuid/:uuid", to: "endpoints#show_by_uuid"
     resources :endpoints, only: [ :create ] do
       resources :requests, only: [ :index, :create ]
     end

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -54,6 +54,8 @@ button:disabled {
   border: 1px solid #bbf7d0;
   padding: 0.5rem;
   border-radius: 4px;
+  overflow-x: auto;
+  white-space: pre-wrap;
 }
 
 .headers {
@@ -61,6 +63,17 @@ button:disabled {
   padding: 0.5rem;
   border-radius: 4px;
   font-size: 0.8rem;
+  overflow-x: auto;
+  word-break: break-all;
+}
+
+.link-box {
+  margin-top: 0.5rem;
+}
+
+.link-box a {
+  color: #2563eb;
+  text-decoration: underline;
 }
 .loading-spinner {
   border: 2px solid rgba(255, 255, 255, 0.3);

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -13,7 +13,7 @@ const Home: React.FC = () => {
     try {
       const res = await fetch('/api/endpoints', { method: 'POST' });
       const data = await res.json();
-      setEndpointUrl(`${window.location.origin}/endpoint/${data.uuid}`);
+      setEndpointUrl(`${window.location.origin}/${data.uuid}`);
       setApiStatus(`Success: ${res.status}`);
       const headersObj: Record<string, string> = {};
       res.headers.forEach((v, k) => {
@@ -37,6 +37,13 @@ const Home: React.FC = () => {
         value={endpointUrl}
         placeholder="Click 'Generate URL' to create an endpoint"
       />
+      {endpointUrl && (
+        <div className="link-box">
+          <a href={endpointUrl} target="_blank" rel="noopener noreferrer">
+            Open endpoint
+          </a>
+        </div>
+      )}
       <button onClick={createEndpoint} disabled={loading} className="btn">
         {loading && <span className="loading-spinner" />} {loading ? 'Creating...' : 'Generate URL'}
       </button>


### PR DESCRIPTION
## Summary
- record GET requests on `/UUID` and redirect to viewer
- adjust URL generation so capture endpoint is the root
- avoid overflow for API response blocks
- show a direct link to open the generated endpoint

## Testing
- `bundle exec rubocop`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d11c40a24832cae71c6e427ea84af