### PR TITLE
Enhance landing and request pages

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -90,3 +90,24 @@ button:disabled {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+.option-card {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+  cursor: pointer;
+  margin-bottom: 1rem;
+}
+
+.option-card:hover {
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+
+.code-box {
+  background-color: #f3f4f6;
+  padding: 0.5rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  overflow-x: auto;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import Home from './pages/Home';
+import LandingPage from './pages/LandingPage';
+import WebhookPage from './pages/WebhookPage';
+import ApiTesterPage from './pages/ApiTesterPage';
 import EndpointPage from './pages/EndpointPage';
 import RequestPage from './pages/RequestPage';
 import './index.css';
@@ -9,7 +11,9 @@ import './index.css';
 const App = () => (
   <BrowserRouter>
     <Routes>
-      <Route path="/" element={<Home />} />
+      <Route path="/" element={<LandingPage />} />
+      <Route path="/webhook" element={<WebhookPage />} />
+      <Route path="/api-test" element={<ApiTesterPage />} />
       <Route path="/endpoint/:uuid" element={<EndpointPage />} />
       <Route path="/endpoint/:uuid/request/:id" element={<RequestPage />} />
     </Routes>

--- a/frontend/src/pages/ApiTesterPage.tsx
+++ b/frontend/src/pages/ApiTesterPage.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+const ApiTesterPage: React.FC = () => {
+  const [testUrl, setTestUrl] = useState('');
+  const [testResult, setTestResult] = useState<{status: number; headers: Record<string,string>; body: string} | null>(null);
+
+  const testApi = async () => {
+    if (!testUrl) return;
+    try {
+      const res = await fetch(testUrl);
+      const body = await res.text();
+      const headersObj: Record<string, string> = {};
+      res.headers.forEach((v, k) => {
+        headersObj[k] = v;
+      });
+      setTestResult({ status: res.status, headers: headersObj, body });
+    } catch (err) {
+      setTestResult({ status: 0, headers: {}, body: 'Request failed' });
+    }
+  };
+
+  return (
+    <div className="container">
+      <h1 className="header">API Tester</h1>
+      <p className="mb-4">Send HTTP requests to quickly inspect status, headers, and body.</p>
+      <input
+        className="url-box"
+        type="text"
+        value={testUrl}
+        onChange={e => setTestUrl(e.target.value)}
+        placeholder="https://example.com/api"
+      />
+      <button onClick={testApi} className="btn mt-2">Send Request</button>
+      {testResult && (
+        <div className="status mt-2">
+          <p>Status: {testResult.status}</p>
+          <pre className="headers">{JSON.stringify(testResult.headers, null, 2)}</pre>
+          <pre className="headers">{testResult.body}</pre>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ApiTesterPage;

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const LandingPage: React.FC = () => (
+  <div className="container">
+    <h1 className="header">Webhook Mirror</h1>
+    <p className="mb-4">WebhookMirror helps you debug webhooks and test APIs. Choose a tool below to get started.</p>
+    <Link to="/webhook" className="option-card block">
+      <h2 className="text-xl font-semibold mb-1">Webhook Endpoint</h2>
+      <p>Generate a unique URL to capture and inspect webhook requests.</p>
+    </Link>
+    <Link to="/api-test" className="option-card block">
+      <h2 className="text-xl font-semibold mb-1">API Tester</h2>
+      <p>Send simple HTTP requests and view the responses instantly.</p>
+    </Link>
+  </div>
+);
+
+export default LandingPage;

--- a/frontend/src/pages/RequestPage.tsx
+++ b/frontend/src/pages/RequestPage.tsx
@@ -27,15 +27,22 @@ const RequestPage: React.FC = () => {
   return (
     <div className="p-8 space-y-4 font-sans">
       <h1 className="text-2xl font-semibold">Request {request.id}</h1>
-      <div className="font-mono text-sm">{request.method} - {request.created_at}</div>
-      <h2 className="font-semibold">Headers</h2>
-      <pre className="whitespace-pre-wrap text-xs mb-4 bg-gray-50 p-2 rounded">
-        {JSON.stringify(request.headers, null, 2)}
-      </pre>
-      <h2 className="font-semibold">Body</h2>
-      <pre className="whitespace-pre-wrap text-xs bg-gray-50 p-2 rounded">
-        {request.body}
-      </pre>
+      <div className="option-card text-left">
+        <h2 className="font-semibold mb-1">General</h2>
+        <div className="font-mono text-sm">{request.method} - {request.created_at}</div>
+      </div>
+      <div className="option-card text-left">
+        <h2 className="font-semibold mb-1">Headers</h2>
+        <pre className="code-box whitespace-pre-wrap text-xs mb-2">
+{JSON.stringify(request.headers, null, 2)}
+        </pre>
+      </div>
+      <div className="option-card text-left">
+        <h2 className="font-semibold mb-1">Body</h2>
+        <pre className="code-box whitespace-pre-wrap text-xs">
+{request.body}
+        </pre>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/WebhookPage.tsx
+++ b/frontend/src/pages/WebhookPage.tsx
@@ -8,7 +8,7 @@ interface Req {
   created_at: string;
 }
 
-const Home: React.FC = () => {
+const WebhookPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [endpointUrl, setEndpointUrl] = useState('');
   const [captureUrl, setCaptureUrl] = useState('');
@@ -18,8 +18,6 @@ const Home: React.FC = () => {
   const [apiStatus, setApiStatus] = useState<string | null>(null);
   const [apiHeaders, setApiHeaders] = useState<Record<string, string> | null>(null);
 
-  const [testUrl, setTestUrl] = useState('');
-  const [testResult, setTestResult] = useState<{status: number; headers: Record<string,string>; body: string} | null>(null);
 
   const createEndpoint = async () => {
     setLoading(true);
@@ -57,25 +55,10 @@ const Home: React.FC = () => {
     }
   }, [endpointId]);
 
-  const testApi = async () => {
-    if (!testUrl) return;
-    try {
-      const res = await fetch(testUrl);
-      const body = await res.text();
-      const headersObj: Record<string, string> = {};
-      res.headers.forEach((v, k) => {
-        headersObj[k] = v;
-      });
-      setTestResult({ status: res.status, headers: headersObj, body });
-    } catch (err) {
-      setTestResult({ status: 0, headers: {}, body: 'Request failed' });
-    }
-  };
-
   return (
     <div className="container">
       <h1 className="header">Webhook Mirror</h1>
-      <p>Generate a unique capture URL to inspect webhook payloads.</p>
+      <p className="mb-4">WebhookMirror lets you capture and inspect HTTP requests. Generate a unique URL below and send your webhooks to it.</p>
       <textarea
         className="url-box"
         readOnly
@@ -87,6 +70,14 @@ const Home: React.FC = () => {
           <a href={endpointUrl} target="_blank" rel="noopener noreferrer">
             Open endpoint
           </a>
+        </div>
+      )}
+      {captureUrl && (
+        <div className="curl-examples">
+          <p className="font-semibold">Example curl POST request</p>
+          <pre className="code-box">{`curl -X POST ${captureUrl} -H "Content-Type: application/json" -d '{"hello":"world"}'`}</pre>
+          <p className="font-semibold mt-2">Example curl GET request</p>
+          <pre className="code-box">{`curl ${captureUrl}`}</pre>
         </div>
       )}
       <button onClick={createEndpoint} disabled={loading} className="btn">
@@ -117,26 +108,8 @@ const Home: React.FC = () => {
           )}
         </div>
       )}
-      <div className="api-test mt-4">
-        <h2 className="header">Test an API</h2>
-        <input
-          className="url-box"
-          type="text"
-          value={testUrl}
-          onChange={e => setTestUrl(e.target.value)}
-          placeholder="https://example.com/api"
-        />
-        <button onClick={testApi} className="btn mt-2">Send Test Request</button>
-        {testResult && (
-          <div className="status mt-2">
-            <p>Status: {testResult.status}</p>
-            <pre className="headers">{JSON.stringify(testResult.headers, null, 2)}</pre>
-            <pre className="headers">{testResult.body}</pre>
-          </div>
-        )}
-      </div>
     </div>
   );
 };
 
-export default Home;
+export default WebhookPage;


### PR DESCRIPTION
## Summary
- create landing page with two option cards for Webhook capture and API testing
- split old Home page into WebhookPage
- add ApiTesterPage for quick request testing
- show example curl commands after generating an endpoint
- beautify request detail page
- style new option and code boxes

## Testing
- `npm run build`
- `bundle exec rails --version`

------
https://chatgpt.com/codex/tasks/task_e_686df460c4d0832cb57948c0ae37e117