### PR TITLE
Improve page styling

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,44 +2,52 @@ body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 0;
-  background-color: #fff;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #6ee7b7, #3b82f6);
 }
 
 .container {
   padding: 2rem;
-  max-width: 600px;
-  margin: 0 auto;
+  max-width: 800px;
+  margin: 2rem auto;
   text-align: center;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.1);
 }
 
 .header {
-  font-size: 2rem;
+  font-size: 2.5rem;
   font-weight: bold;
   margin-bottom: 0.5rem;
-  color: #16a34a;
+  color: #3b82f6;
 }
 
 .btn {
-  background-color: #16a34a;
+  background-color: #3b82f6;
   color: #fff;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;
   cursor: pointer;
+  display: inline-block;
 }
 
 .btn:hover {
-  background-color: #15803d;
+  background-color: #2563eb;
 }
 
-textarea.url-box {
+.url-box {
   width: 100%;
-  max-width: 500px;
-  min-height: 60px;
-  padding: 0.5rem;
+  max-width: 100%;
+  min-height: 40px;
+  padding: 0.75rem;
   border: 1px solid #ccc;
   border-radius: 4px;
   resize: none;
+  font-size: 1rem;
+  margin-bottom: 0.75rem;
+  box-sizing: border-box;
 }
 
 button:disabled {
@@ -111,3 +119,23 @@ button:disabled {
   font-size: 0.85rem;
   overflow-x: auto;
 }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-4 { margin-bottom: 1rem; }
+.mt-2 { margin-top: 0.5rem; }
+.block { display: block; }
+.option-card h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem;
+}
+.font-semibold { font-weight: 600; }
+.text-xl { font-size: 1.25rem; }
+.text-2xl { font-size: 1.5rem; }
+.text-sm { font-size: 0.875rem; }
+.font-mono { font-family: monospace; }
+.border { border: 1px solid #ccc; }
+.rounded { border-radius: 4px; }
+.p-2 { padding: 0.5rem; }
+.p-3 { padding: 0.75rem; }
+.space-y-2 > * + * { margin-top: 0.5rem; }
+.whitespace-pre-wrap { white-space: pre-wrap; }

--- a/frontend/src/pages/ApiTesterPage.tsx
+++ b/frontend/src/pages/ApiTesterPage.tsx
@@ -30,7 +30,7 @@ const ApiTesterPage: React.FC = () => {
         onChange={e => setTestUrl(e.target.value)}
         placeholder="https://example.com/api"
       />
-      <button onClick={testApi} className="btn mt-2">Send Request</button>
+      <button onClick={testApi} className="btn">Send Request</button>
       {testResult && (
         <div className="status mt-2">
           <p>Status: {testResult.status}</p>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -5,12 +5,12 @@ const LandingPage: React.FC = () => (
   <div className="container">
     <h1 className="header">Webhook Mirror</h1>
     <p className="mb-4">WebhookMirror helps you debug webhooks and test APIs. Choose a tool below to get started.</p>
-    <Link to="/webhook" className="option-card block">
-      <h2 className="text-xl font-semibold mb-1">Webhook Endpoint</h2>
+    <Link to="/webhook" className="option-card block mb-2">
+      <h2>Webhook Endpoint</h2>
       <p>Generate a unique URL to capture and inspect webhook requests.</p>
     </Link>
     <Link to="/api-test" className="option-card block">
-      <h2 className="text-xl font-semibold mb-1">API Tester</h2>
+      <h2>API Tester</h2>
       <p>Send simple HTTP requests and view the responses instantly.</p>
     </Link>
   </div>


### PR DESCRIPTION
## Summary
- refresh the frontend theme with a gradient background and card-style container
- refine API tester layout and spacing
- tidy landing page link cards

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686df63b07d4832c85e8978cf96c17ea