### PR TITLE
Improve requests page style

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -137,5 +137,13 @@ button:disabled {
 .rounded { border-radius: 4px; }
 .p-2 { padding: 0.5rem; }
 .p-3 { padding: 0.75rem; }
+.p-8 { padding: 2rem; }
 .space-y-2 > * + * { margin-top: 0.5rem; }
+.space-y-1 > * + * { margin-top: 0.25rem; }
+.space-y-4 > * + * { margin-top: 1rem; }
 .whitespace-pre-wrap { white-space: pre-wrap; }
+.text-xs { font-size: 0.75rem; }
+.text-left { text-align: left; }
+.font-sans { font-family: Arial, sans-serif; }
+.mb-1 { margin-bottom: 0.25rem; }
+.bg-gray-50 { background-color: #f9fafb; }

--- a/frontend/src/pages/EndpointPage.tsx
+++ b/frontend/src/pages/EndpointPage.tsx
@@ -34,24 +34,26 @@ const EndpointPage: React.FC = () => {
   }, [endpointId]);
 
   return (
-    <div className="p-8 space-y-4 font-sans">
-      <h1 className="text-2xl font-semibold">Requests for {uuid}</h1>
-      {requests.length === 0 ? (
-        <p>No requests yet.</p>
-      ) : (
-        <ul className="space-y-2">
-          {requests.map(r => (
-            <li key={r.id} className="border rounded p-3 space-y-1">
-              <div className="font-mono text-sm">
-                <Link to={`/endpoint/${uuid}/request/${r.id}`}>{r.method} - {r.created_at}</Link>
-              </div>
-              <pre className="whitespace-pre-wrap text-xs bg-gray-50 p-2 rounded">
-                {r.body}
-              </pre>
-            </li>
-          ))}
-        </ul>
-      )}
+    <div className="container">
+      <div className="space-y-4">
+        <h1 className="header">Requests for {uuid}</h1>
+        {requests.length === 0 ? (
+          <p>No requests yet.</p>
+        ) : (
+          <ul className="space-y-2 text-left">
+            {requests.map(r => (
+              <li key={r.id} className="border rounded p-3 space-y-1">
+                <div className="font-mono text-sm">
+                  <Link to={`/endpoint/${uuid}/request/${r.id}`}>{r.method} - {r.created_at}</Link>
+                </div>
+                <pre className="whitespace-pre-wrap text-xs bg-gray-50 p-2 rounded">
+                  {r.body}
+                </pre>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/RequestPage.tsx
+++ b/frontend/src/pages/RequestPage.tsx
@@ -25,23 +25,25 @@ const RequestPage: React.FC = () => {
   if (!request) return <div className="p-8 font-sans">Loading...</div>;
 
   return (
-    <div className="p-8 space-y-4 font-sans">
-      <h1 className="text-2xl font-semibold">Request {request.id}</h1>
-      <div className="option-card text-left">
-        <h2 className="font-semibold mb-1">General</h2>
-        <div className="font-mono text-sm">{request.method} - {request.created_at}</div>
-      </div>
-      <div className="option-card text-left">
-        <h2 className="font-semibold mb-1">Headers</h2>
-        <pre className="code-box whitespace-pre-wrap text-xs mb-2">
+    <div className="container">
+      <div className="space-y-4">
+        <h1 className="header">Request {request.id}</h1>
+        <div className="option-card text-left">
+          <h2 className="font-semibold mb-1">General</h2>
+          <div className="font-mono text-sm">{request.method} - {request.created_at}</div>
+        </div>
+        <div className="option-card text-left">
+          <h2 className="font-semibold mb-1">Headers</h2>
+          <pre className="code-box whitespace-pre-wrap text-xs mb-2">
 {JSON.stringify(request.headers, null, 2)}
-        </pre>
-      </div>
-      <div className="option-card text-left">
-        <h2 className="font-semibold mb-1">Body</h2>
-        <pre className="code-box whitespace-pre-wrap text-xs">
+          </pre>
+        </div>
+        <div className="option-card text-left">
+          <h2 className="font-semibold mb-1">Body</h2>
+          <pre className="code-box whitespace-pre-wrap text-xs">
 {request.body}
-        </pre>
+          </pre>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- define more utility CSS classes like `text-xs`, `bg-gray-50`, and spacing helpers
- update endpoint request list to use the shared container layout
- align single request view with updated styling

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_686df7b72f1c832cba3b6802711b8430