### PR TITLE
Fix README and endpoint page URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The UI follows [Neetix](https://neetix.neetokb.com/) best practices such as usin
 ### Generating a capture URL
 
 1. Visit the homepage and click **Create Endpoint**.
-2. A unique URL containing a UUID will be generated, for example `http://localhost:5173/endpoint/abcd-1234`.
+2. A unique URL containing a UUID will be generated, for example `http://localhost:3000/endpoint/abcd-1234`.
 3. Send any HTTP request to this URL using `curl` or your integration. The Rails API will store the payload.
 4. Open the URL in your browser to see the list of requests as they arrive. Click a request to view its full details.
 
@@ -45,12 +45,12 @@ Use `curl` to hit your generated URL. Replace `<uuid>` with the value shown in t
 
 ```bash
 # POST with JSON body
-curl -X POST http://localhost:5173/<uuid> \
+curl -X POST http://localhost:3000/<uuid> \
      -H "Content-Type: application/json" \
      -d '{"hello": "world"}'
 
 # Simple GET
-curl http://localhost:5173/<uuid>
+curl http://localhost:3000/<uuid>
 ```
 
 ### Inspecting requests

--- a/frontend/src/pages/WebhookPage.tsx
+++ b/frontend/src/pages/WebhookPage.tsx
@@ -26,8 +26,12 @@ const WebhookPage: React.FC = () => {
     try {
       const res = await fetch('/api/endpoints', { method: 'POST' });
       const data = await res.json();
-      setCaptureUrl(`${window.location.origin}/${data.uuid}`);
-      setEndpointUrl(`${window.location.origin}/endpoint/${data.uuid}`);
+      const { protocol, hostname } = window.location;
+      const baseUrl = hostname === 'localhost'
+        ? `${protocol}//${hostname}:3000`
+        : window.location.origin;
+      setCaptureUrl(`${baseUrl}/${data.uuid}`);
+      setEndpointUrl(`${baseUrl}/endpoint/${data.uuid}`);
       setEndpointId(data.id);
       setApiStatus(`Success: ${res.status}`);
       const headersObj: Record<string, string> = {};


### PR DESCRIPTION
## Summary
- correct example localhost port in docs to 3000
- generate capture URLs on the endpoint page using port 3000

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686df9be5488832cbe072db2e3336612