### PR TITLE
Add sidebar to landing page

### DIFF
--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#3b82f6" />
+  <path d="M25 30 L50 70 L75 30 Z" fill="#ffffff" />
+</svg>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -147,3 +147,39 @@ button:disabled {
 .font-sans { font-family: Arial, sans-serif; }
 .mb-1 { margin-bottom: 0.25rem; }
 .bg-gray-50 { background-color: #f9fafb; }
+
+/* Layout styles for landing page with sidebar */
+.layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 220px;
+  background: #ffffff;
+  border-right: 1px solid #ccc;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.sidebar .logo img {
+  width: 150px;
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.nav-item {
+  margin-bottom: 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: #374151;
+}
+
+.nav-item.active {
+  color: #3b82f6;
+}
+
+.main-content {
+  flex: 1;
+  overflow-y: auto;
+}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,19 +1,35 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useState } from 'react';
+import WebhookPage from './WebhookPage';
+import ApiTesterPage from './ApiTesterPage';
 
-const LandingPage: React.FC = () => (
-  <div className="container">
-    <h1 className="header">Webhook Mirror</h1>
-    <p className="mb-4">WebhookMirror helps you debug webhooks and test APIs. Choose a tool below to get started.</p>
-    <Link to="/webhook" className="option-card block mb-2">
-      <h2>Webhook Endpoint</h2>
-      <p>Generate a unique URL to capture and inspect webhook requests.</p>
-    </Link>
-    <Link to="/api-test" className="option-card block">
-      <h2>API Tester</h2>
-      <p>Send simple HTTP requests and view the responses instantly.</p>
-    </Link>
-  </div>
-);
+const LandingPage: React.FC = () => {
+  const [active, setActive] = useState<'webhook' | 'api'>('webhook');
+
+  return (
+    <div className="layout">
+      <div className="sidebar">
+        <div className="logo">
+          <img src="/logo.svg" alt="WebhookMirror logo" />
+        </div>
+        <div
+          className={`nav-item ${active === 'webhook' ? 'active' : ''}`}
+          onClick={() => setActive('webhook')}
+        >
+          Webhook Endpoint
+        </div>
+        <div
+          className={`nav-item ${active === 'api' ? 'active' : ''}`}
+          onClick={() => setActive('api')}
+        >
+          API Testing
+        </div>
+      </div>
+      <div className="main-content">
+        {active === 'webhook' && <WebhookPage />}
+        {active === 'api' && <ApiTesterPage />}
+      </div>
+    </div>
+  );
+};
 
 export default LandingPage;


### PR DESCRIPTION
## Summary
- redesign the landing page with a persistent sidebar
- sidebar toggles Webhook Endpoint and API Testing views
- add a simple WebhookMirror logo
- include layout styling in CSS

## Testing
- `npm run build`
- `bin/rails db:migrate`


------
https://chatgpt.com/codex/tasks/task_e_686dfdb948cc832c9f7dcb75876b9813