### PR TITLE
Add advanced UI API tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ curl -X POST http://localhost:3000/<uuid> \
 curl http://localhost:3000/<uuid>
 ```
 
+### API testing from the UI
+
+Navigate to `/api-test` in the frontend to open the **API Tester**. Enter the inbox URL you wish to target and customize the HTTP method, query parameters, headers and body. The response status, headers and body are shown instantly so you can simulate webhook calls without third-party tools.
+
 ### Inspecting requests
 
 * After sending requests, open the generated endpoint page in your browser.

--- a/frontend/src/pages/ApiTesterPage.tsx
+++ b/frontend/src/pages/ApiTesterPage.tsx
@@ -2,18 +2,40 @@ import React, { useState } from 'react';
 
 const ApiTesterPage: React.FC = () => {
   const [testUrl, setTestUrl] = useState('');
+  const [method, setMethod] = useState('GET');
+  const [query, setQuery] = useState('');
+  const [headersText, setHeadersText] = useState('');
+  const [bodyText, setBodyText] = useState('');
   const [testResult, setTestResult] = useState<{status: number; headers: Record<string,string>; body: string} | null>(null);
 
   const testApi = async () => {
     if (!testUrl) return;
     try {
-      const res = await fetch(testUrl);
-      const body = await res.text();
+      let finalUrl = testUrl;
+      if (query) {
+        const q = query.startsWith('?') ? query.slice(1) : query;
+        finalUrl += (testUrl.includes('?') ? '&' : '?') + q;
+      }
       const headersObj: Record<string, string> = {};
-      res.headers.forEach((v, k) => {
-        headersObj[k] = v;
+      headersText.split('\n').forEach(line => {
+        const idx = line.indexOf(':');
+        if (idx > -1) {
+          const key = line.slice(0, idx).trim();
+          const value = line.slice(idx + 1).trim();
+          if (key) headersObj[key] = value;
+        }
       });
-      setTestResult({ status: res.status, headers: headersObj, body });
+      const options: RequestInit = { method, headers: headersObj };
+      if (bodyText && method !== 'GET' && method !== 'HEAD') {
+        options.body = bodyText;
+      }
+      const res = await fetch(finalUrl, options);
+      const body = await res.text();
+      const respHeaders: Record<string, string> = {};
+      res.headers.forEach((v, k) => {
+        respHeaders[k] = v;
+      });
+      setTestResult({ status: res.status, headers: respHeaders, body });
     } catch (err) {
       setTestResult({ status: 0, headers: {}, body: 'Request failed' });
     }
@@ -28,7 +50,37 @@ const ApiTesterPage: React.FC = () => {
         type="text"
         value={testUrl}
         onChange={e => setTestUrl(e.target.value)}
-        placeholder="https://example.com/api"
+        placeholder="https://example.com/inbox-uuid"
+      />
+      <div className="mb-2">
+        <select className="url-box" value={method} onChange={e => setMethod(e.target.value)}>
+          <option value="GET">GET</option>
+          <option value="POST">POST</option>
+          <option value="PUT">PUT</option>
+          <option value="PATCH">PATCH</option>
+          <option value="DELETE">DELETE</option>
+        </select>
+      </div>
+      <input
+        className="url-box"
+        type="text"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        placeholder="query=params&foo=bar"
+      />
+      <textarea
+        className="url-box"
+        rows={3}
+        value={headersText}
+        onChange={e => setHeadersText(e.target.value)}
+        placeholder="Header: Value"
+      />
+      <textarea
+        className="url-box"
+        rows={4}
+        value={bodyText}
+        onChange={e => setBodyText(e.target.value)}
+        placeholder="Request body"
       />
       <button onClick={testApi} className="btn">Send Request</button>
       {testResult && (


### PR DESCRIPTION
## Summary
- allow selecting method, params, headers and body in API tester
- document API tester usage in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e0431da78832c80f2bc694adcb223