### PR TITLE
Implement dashboard and enhanced endpoint UI

### DIFF
--- a/backend/app/controllers/api/endpoints_controller.rb
+++ b/backend/app/controllers/api/endpoints_controller.rb
@@ -1,4 +1,9 @@
 class Api::EndpointsController < ApplicationController
+  def index
+    endpoints = Endpoint.order(created_at: :desc)
+    render json: endpoints
+  end
+
   def create
     endpoint = Endpoint.create!(uuid: SecureRandom.uuid)
     render json: { id: endpoint.id, uuid: endpoint.uuid }

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     get "endpoints/by_uuid/:uuid", to: "endpoints#show_by_uuid"
-    resources :endpoints, only: [ :create ] do
+    resources :endpoints, only: [ :create, :index ] do
       resources :requests, only: [ :index, :create ]
     end
     resources :requests, only: [ :show ]

--- a/frontend/src/components/LiveIndicator.tsx
+++ b/frontend/src/components/LiveIndicator.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const LiveIndicator: React.FC = () => (
+  <span className="live-indicator" title="Live updating" />
+);
+
+export default LiveIndicator;

--- a/frontend/src/components/RequestInspector.tsx
+++ b/frontend/src/components/RequestInspector.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import Tabs from './Tabs';
+
+interface Props {
+  request: {
+    id: number;
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+    created_at: string;
+  };
+}
+
+const RequestInspector: React.FC<Props> = ({ request }) => {
+  const [active, setActive] = useState('Raw');
+  const queryParams = new URLSearchParams(request.headers['query-string'] || '');
+  const cookies = request.headers['cookie'] || '';
+
+  return (
+    <div className="inspector">
+      <h2 className="text-xl mb-2">Request {request.id}</h2>
+      <Tabs tabs={['Raw', 'Headers', 'Body', 'Query Params', 'Cookies']} active={active} onChange={setActive} />
+      {active === 'Raw' && (
+        <pre className="code-box whitespace-pre-wrap text-xs">{JSON.stringify(request, null, 2)}</pre>
+      )}
+      {active === 'Headers' && (
+        <pre className="code-box whitespace-pre-wrap text-xs">{JSON.stringify(request.headers, null, 2)}</pre>
+      )}
+      {active === 'Body' && (
+        <pre className="code-box whitespace-pre-wrap text-xs">{request.body}</pre>
+      )}
+      {active === 'Query Params' && (
+        <pre className="code-box whitespace-pre-wrap text-xs">{Array.from(queryParams.entries()).map(([k,v]) => `${k}: ${v}`).join('\n') || 'None'}</pre>
+      )}
+      {active === 'Cookies' && (
+        <pre className="code-box whitespace-pre-wrap text-xs">{cookies || 'None'}</pre>
+      )}
+    </div>
+  );
+};
+
+export default RequestInspector;

--- a/frontend/src/components/RequestList.tsx
+++ b/frontend/src/components/RequestList.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import RequestListItem, { Req } from './RequestListItem';
+
+interface Props {
+  requests: Req[];
+  activeId: number | null;
+  onSelect: (r: Req) => void;
+}
+
+const RequestList: React.FC<Props> = ({ requests, activeId, onSelect }) => (
+  <ul className="space-y-2 request-list text-left">
+    {requests.map(r => (
+      <RequestListItem
+        key={r.id}
+        request={r}
+        active={r.id === activeId}
+        onClick={() => onSelect(r)}
+      />
+    ))}
+  </ul>
+);
+
+export default RequestList;

--- a/frontend/src/components/RequestListItem.tsx
+++ b/frontend/src/components/RequestListItem.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export interface Req {
+  id: number;
+  method: string;
+  headers: Record<string, string>;
+  body: string;
+  created_at: string;
+}
+
+interface Props {
+  request: Req;
+  onClick: () => void;
+  active: boolean;
+}
+
+const RequestListItem: React.FC<Props> = ({ request, onClick, active }) => (
+  <li
+    className={active ? 'request-item active' : 'request-item'}
+    onClick={onClick}
+  >
+    <div className="flex justify-between">
+      <span className="font-mono text-sm">{request.method}</span>
+      <span className="text-xs">{new Date(request.created_at).toLocaleTimeString()}</span>
+    </div>
+    <pre className="code-box whitespace-pre-wrap text-xs mt-1">
+      {request.body.slice(0, 80)}
+    </pre>
+  </li>
+);
+
+export default RequestListItem;

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface Props {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+const SearchInput: React.FC<Props> = ({ value, onChange }) => (
+  <input
+    className="url-box"
+    type="text"
+    placeholder="Search"
+    value={value}
+    onChange={e => onChange(e.target.value)}
+  />
+);
+
+export default SearchInput;

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface TabsProps {
+  tabs: string[];
+  active: string;
+  onChange: (tab: string) => void;
+}
+
+const Tabs: React.FC<TabsProps> = ({ tabs, active, onChange }) => (
+  <div className="tabs">
+    {tabs.map(t => (
+      <button
+        key={t}
+        className={active === t ? 'tab active' : 'tab'}
+        onClick={() => onChange(t)}
+      >
+        {t}
+      </button>
+    ))}
+  </div>
+);
+
+export default Tabs;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -181,3 +181,69 @@ button:disabled {
   flex: 1;
   overflow-y: auto;
 }
+/* Tabs */
+.tabs {
+  display: flex;
+  border-bottom: 1px solid #e5e7eb;
+  margin-bottom: 0.5rem;
+}
+.tab {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border: none;
+  background: none;
+  font-weight: 600;
+  color: #374151;
+}
+.tab.active {
+  border-bottom: 2px solid #3b82f6;
+  color: #3b82f6;
+}
+.live-indicator {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: #10b981;
+  animation: pulse 1s ease-in-out infinite;
+  margin-left: 0.25rem;
+}
+@keyframes pulse {
+  0% { opacity: 0.4; }
+  50% { opacity: 1; }
+  100% { opacity: 0.4; }
+}
+.inspector {
+  position: sticky;
+  top: 1rem;
+  border: 1px solid #e5e7eb;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+  background-color: #fff;
+}
+.request-item {
+  border: 1px solid #e5e7eb;
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.request-item.active {
+  background-color: #eef2ff;
+  border-color: #6366f1;
+}
+.request-list {
+  max-height: 80vh;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+.flex {
+  display: flex;
+}
+.justify-between {
+  justify-content: space-between;
+}
+.w-full { width: 100%; }
+.mt-4 { margin-top: 1rem; }
+.table { width: 100%; border-collapse: collapse; }
+.table th, .table td { padding: 0.5rem; border-bottom: 1px solid #e5e7eb; }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import LandingPage from './pages/LandingPage';
+import DashboardPage from './pages/DashboardPage';
 import WebhookPage from './pages/WebhookPage';
 import ApiTesterPage from './pages/ApiTesterPage';
 import EndpointPage from './pages/EndpointPage';
@@ -12,6 +13,7 @@ const App = () => (
   <BrowserRouter>
     <Routes>
       <Route path="/" element={<LandingPage />} />
+      <Route path="/dashboard" element={<DashboardPage />} />
       <Route path="/webhook" element={<WebhookPage />} />
       <Route path="/api-test" element={<ApiTesterPage />} />
       <Route path="/endpoint/:uuid" element={<EndpointPage />} />

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+interface Endpoint {
+  id: number;
+  uuid: string;
+  created_at: string;
+}
+
+const DashboardPage: React.FC = () => {
+  const [endpoints, setEndpoints] = useState<Endpoint[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadEndpoints = async () => {
+    setLoading(true);
+    const res = await fetch('/api/endpoints');
+    const data = await res.json();
+    setEndpoints(data);
+    setLoading(false);
+  };
+
+  useEffect(() => { loadEndpoints(); }, []);
+
+  const createEndpoint = async () => {
+    await fetch('/api/endpoints', { method: 'POST' });
+    loadEndpoints();
+  };
+
+  return (
+    <div className="container">
+      <h1 className="header">Dashboard</h1>
+      <button className="btn mb-4" onClick={createEndpoint}>Create new endpoint</button>
+      {loading ? <p>Loading...</p> : (
+        <table className="w-full text-left">
+          <thead>
+            <tr><th>UUID</th><th>Created</th></tr>
+          </thead>
+          <tbody>
+            {endpoints.map(e => (
+              <tr key={e.id}>
+                <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
+                <td>{new Date(e.created_at).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/frontend/src/pages/EndpointPage.tsx
+++ b/frontend/src/pages/EndpointPage.tsx
@@ -1,18 +1,19 @@
 import React, { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import RequestList from '../components/RequestList';
+import { Req } from '../components/RequestListItem';
+import RequestInspector from '../components/RequestInspector';
+import SearchInput from '../components/SearchInput';
+import LiveIndicator from '../components/LiveIndicator';
 
-interface Req {
-  id: number;
-  method: string;
-  headers: Record<string, string>;
-  body: string;
-  created_at: string;
-}
 
 const EndpointPage: React.FC = () => {
   const { uuid } = useParams();
   const [endpointId, setEndpointId] = useState<number | null>(null);
   const [requests, setRequests] = useState<Req[]>([]);
+  const [selected, setSelected] = useState<Req | null>(null);
+  const [search, setSearch] = useState('');
+  const [methodFilter, setMethodFilter] = useState('');
 
   useEffect(() => {
     const fetchEndpoint = async () => {
@@ -31,28 +32,46 @@ const EndpointPage: React.FC = () => {
       setRequests(data);
     };
     loadRequests();
+    const interval = setInterval(loadRequests, 5000);
+    return () => clearInterval(interval);
   }, [endpointId]);
 
+  const filtered = requests.filter(r => {
+    const matchesMethod = methodFilter ? r.method === methodFilter : true;
+    const text = (r.body + JSON.stringify(r.headers)).toLowerCase();
+    const matchesSearch = search ? text.includes(search.toLowerCase()) : true;
+    return matchesMethod && matchesSearch;
+  });
+
   return (
-    <div className="container">
-      <div className="space-y-4">
-        <h1 className="header">Requests for {uuid}</h1>
-        {requests.length === 0 ? (
-          <p>No requests yet.</p>
-        ) : (
-          <ul className="space-y-2 text-left">
-            {requests.map(r => (
-              <li key={r.id} className="border rounded p-3 space-y-1">
-                <div className="font-mono text-sm">
-                  <Link to={`/endpoint/${uuid}/request/${r.id}`}>{r.method} - {r.created_at}</Link>
-                </div>
-                <pre className="whitespace-pre-wrap text-xs bg-gray-50 p-2 rounded">
-                  {r.body}
-                </pre>
-              </li>
-            ))}
-          </ul>
-        )}
+    <div className="container" style={{maxWidth: '1200px'}}>
+      <h1 className="header">Endpoint {uuid} <LiveIndicator /></h1>
+      <div className="flex" style={{gap: '1rem', alignItems: 'flex-start'}}>
+        <div style={{flex: '1'}}>
+          <div className="mb-2 flex" style={{gap: '0.5rem'}}>
+            <select className="url-box" value={methodFilter} onChange={e => setMethodFilter(e.target.value)}>
+              <option value="">All methods</option>
+              <option value="GET">GET</option>
+              <option value="POST">POST</option>
+              <option value="PUT">PUT</option>
+              <option value="PATCH">PATCH</option>
+              <option value="DELETE">DELETE</option>
+            </select>
+            <SearchInput value={search} onChange={setSearch} />
+          </div>
+          {filtered.length === 0 ? (
+            <p>No requests yet.</p>
+          ) : (
+            <RequestList requests={filtered} activeId={selected?.id || null} onSelect={setSelected} />
+          )}
+        </div>
+        <div style={{flex: '1'}}>
+          {selected ? (
+            <RequestInspector request={selected} />
+          ) : (
+            <p>Select a request to inspect</p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,29 +1,24 @@
-import React, { useState } from 'react';
-import WebhookPage from './WebhookPage';
-import ApiTesterPage from './ApiTesterPage';
+import React from 'react';
+import { useNavigate, Link } from 'react-router-dom';
 
 const LandingPage: React.FC = () => {
-  const [active, setActive] = useState<'webhook' | 'api'>('webhook');
+  const navigate = useNavigate();
+
+  const createEndpoint = async () => {
+    const res = await fetch('/api/endpoints', { method: 'POST' });
+    const data = await res.json();
+    navigate(`/endpoint/${data.uuid}`);
+  };
 
   return (
-      <div className="layout">
-        <div className="sidebar">
-          <div
-            className={`nav-item ${active === 'webhook' ? 'active' : ''}`}
-            onClick={() => setActive('webhook')}
-          >
-            Webhook Endpoint
-          </div>
-          <div
-            className={`nav-item ${active === 'api' ? 'active' : ''}`}
-            onClick={() => setActive('api')}
-          >
-            API Testing
-          </div>
-        </div>
-      <div className="main-content">
-        {active === 'webhook' && <WebhookPage />}
-        {active === 'api' && <ApiTesterPage />}
+    <div className="container">
+      <h1 className="header">Webhook Mirror</h1>
+      <p className="mb-4">Capture and inspect HTTP requests in real time.</p>
+      <button className="btn mb-4" onClick={createEndpoint}>Create new endpoint</button>
+      <p className="mb-2">Example curl command:</p>
+      <pre className="code-box">curl -X POST https://your-endpoint-id -d '{{"hello":"world"}}'</pre>
+      <div className="mt-4 text-sm">
+        <Link to="/dashboard">Go to dashboard</Link> | <Link to="/api-test">API tester</Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `index` API endpoint for listing endpoints
- create Dashboard page and allow generating endpoints
- overhaul Landing page with call-to-action redirecting to new endpoint
- rework Endpoint page with live updates, filters and inspector panel
- add reusable components for tabs, request lists and live indicator

## Testing
- `npm run build`
- `bundle exec rails --version`
- `bundle exec rails routes | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_686e35df93a0832cab6bccc2db76ed9a