### PR TITLE
Fix LandingPage JSX string quoting

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -16,7 +16,7 @@ const LandingPage: React.FC = () => {
       <p className="mb-4">Capture and inspect HTTP requests in real time.</p>
       <button className="btn mb-4" onClick={createEndpoint}>Create new endpoint</button>
       <p className="mb-2">Example curl command:</p>
-      <pre className="code-box">curl -X POST https://your-endpoint-id -d '{{"hello":"world"}}'</pre>
+      <pre className="code-box">{`curl -X POST https://your-endpoint-id -d '{"hello":"world"}'`}</pre>
       <div className="mt-4 text-sm">
         <Link to="/dashboard">Go to dashboard</Link> | <Link to="/api-test">API tester</Link>
       </div>


### PR DESCRIPTION
## Summary
- fix the curl example string quoting in LandingPage.tsx
- rebuild frontend to ensure it compiles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e387ae394832ca0a7a1ee0434b8a7