### PR TITLE
Improve dashboard sorting and navigation

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,7 +3,7 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
-  background: linear-gradient(135deg, #6ee7b7, #3b82f6);
+  background: #f9fafb;
 }
 
 .container {
@@ -20,11 +20,11 @@ body {
   font-size: 2.5rem;
   font-weight: bold;
   margin-bottom: 0.5rem;
-  color: #3b82f6;
+  color: #1f2937;
 }
 
 .btn {
-  background-color: #3b82f6;
+  background-color: #2563eb;
   color: #fff;
   border: none;
   padding: 0.5rem 1rem;
@@ -34,7 +34,7 @@ body {
 }
 
 .btn:hover {
-  background-color: #2563eb;
+  background-color: #1d4ed8;
 }
 
 .url-box {
@@ -173,8 +173,8 @@ button:disabled {
 
 .nav-item.active {
   background: #f3f4f6;
-  border-left: 4px solid #3b82f6;
-  color: #3b82f6;
+  border-left: 4px solid #2563eb;
+  color: #2563eb;
 }
 
 .main-content {
@@ -196,8 +196,8 @@ button:disabled {
   color: #374151;
 }
 .tab.active {
-  border-bottom: 2px solid #3b82f6;
-  color: #3b82f6;
+  border-bottom: 2px solid #2563eb;
+  color: #2563eb;
 }
 .live-indicator {
   display: inline-block;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
 interface Endpoint {
@@ -21,6 +21,26 @@ const DashboardPage: React.FC = () => {
 
   useEffect(() => { loadEndpoints(); }, []);
 
+  const groups = useMemo(() => {
+    const today: Endpoint[] = [];
+    const yesterday: Endpoint[] = [];
+    const older: Endpoint[] = [];
+    const now = new Date();
+    const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const startOfYesterday = new Date(startOfToday.getTime() - 86400000);
+    endpoints.forEach(e => {
+      const created = new Date(e.created_at);
+      if (created >= startOfToday) {
+        today.push(e);
+      } else if (created >= startOfYesterday) {
+        yesterday.push(e);
+      } else {
+        older.push(e);
+      }
+    });
+    return { today, yesterday, older };
+  }, [endpoints]);
+
   const createEndpoint = async () => {
     await fetch('/api/endpoints', { method: 'POST' });
     loadEndpoints();
@@ -29,6 +49,9 @@ const DashboardPage: React.FC = () => {
   return (
     <div className="container">
       <h1 className="header">Dashboard</h1>
+      <div className="mb-2 text-sm">
+        <Link to="/">Back to home</Link>
+      </div>
       <button className="btn mb-4" onClick={createEndpoint}>Create new endpoint</button>
       {loading ? <p>Loading...</p> : (
         <table className="w-full text-left">
@@ -36,7 +59,28 @@ const DashboardPage: React.FC = () => {
             <tr><th>UUID</th><th>Created</th></tr>
           </thead>
           <tbody>
-            {endpoints.map(e => (
+            {groups.today.length > 0 && (
+              <tr><th colSpan={2}>Today</th></tr>
+            )}
+            {groups.today.map(e => (
+              <tr key={e.id}>
+                <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
+                <td>{new Date(e.created_at).toLocaleString()}</td>
+              </tr>
+            ))}
+            {groups.yesterday.length > 0 && (
+              <tr><th colSpan={2}>Yesterday</th></tr>
+            )}
+            {groups.yesterday.map(e => (
+              <tr key={e.id}>
+                <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
+                <td>{new Date(e.created_at).toLocaleString()}</td>
+              </tr>
+            ))}
+            {groups.older.length > 0 && (
+              <tr><th colSpan={2}>Older</th></tr>
+            )}
+            {groups.older.map(e => (
               <tr key={e.id}>
                 <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
                 <td>{new Date(e.created_at).toLocaleString()}</td>

--- a/frontend/src/pages/EndpointPage.tsx
+++ b/frontend/src/pages/EndpointPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import RequestList from '../components/RequestList';
 import { Req } from '../components/RequestListItem';
 import RequestInspector from '../components/RequestInspector';
@@ -46,6 +46,9 @@ const EndpointPage: React.FC = () => {
   return (
     <div className="container" style={{maxWidth: '1200px'}}>
       <h1 className="header">Endpoint {uuid} <LiveIndicator /></h1>
+      <div className="mb-2 text-sm text-left">
+        <Link to="/">Back to home</Link>
+      </div>
       <div className="flex" style={{gap: '1rem', alignItems: 'flex-start'}}>
         <div style={{flex: '1'}}>
           <div className="mb-2 flex" style={{gap: '0.5rem'}}>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -16,7 +16,7 @@ const LandingPage: React.FC = () => {
       <p className="mb-4">Capture and inspect HTTP requests in real time.</p>
       <button className="btn mb-4" onClick={createEndpoint}>Create new endpoint</button>
       <p className="mb-2">Example curl command:</p>
-      <pre className="code-box">{`curl -X POST https://your-endpoint-id -d '{"hello":"world"}'`}</pre>
+      <pre className="code-box">{`curl -X POST http://localhost:3000/<endpoint-id> -H "Content-Type: application/json" -d '{"hello":"world"}'`}</pre>
       <div className="mt-4 text-sm">
         <Link to="/dashboard">Go to dashboard</Link> | <Link to="/api-test">API tester</Link>
       </div>


### PR DESCRIPTION
## Summary
- group dashboard endpoints into Today/Yesterday/Older
- add navigation links back to home on dashboard and endpoint pages
- show a full curl command on the landing page example
- tone down UI colors for a cleaner look

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e3e5dc710832c8e8e8a698b09c3ae