### PR TITLE
Improve dashboard and request viewer

### DIFF
--- a/backend/app/controllers/api/endpoints_controller.rb
+++ b/backend/app/controllers/api/endpoints_controller.rb
@@ -13,4 +13,16 @@ class Api::EndpointsController < ApplicationController
     endpoint = Endpoint.find_by!(uuid: params[:uuid])
     render json: { id: endpoint.id, uuid: endpoint.uuid }
   end
+
+  def update
+    endpoint = Endpoint.find(params[:id])
+    endpoint.update!(disabled: params[:disabled])
+    render json: endpoint
+  end
+
+  def destroy
+    endpoint = Endpoint.find(params[:id])
+    endpoint.destroy!
+    head :no_content
+  end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     get "endpoints/by_uuid/:uuid", to: "endpoints#show_by_uuid"
-    resources :endpoints, only: [ :create, :index ] do
+    resources :endpoints, only: [ :create, :index, :update, :destroy ] do
       resources :requests, only: [ :index, :create ]
     end
     resources :requests, only: [ :show ]

--- a/backend/db/migrate/20250709101747_add_disabled_to_endpoints.rb
+++ b/backend/db/migrate/20250709101747_add_disabled_to_endpoints.rb
@@ -1,0 +1,5 @@
+class AddDisabledToEndpoints < ActiveRecord::Migration[8.0]
+  def change
+    add_column :endpoints, :disabled, :boolean, default: false
+  end
+end

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-json-tree": "^0.20.0",
     "react-router-dom": "^6.23.0"
   },
   "devDependencies": {

--- a/frontend/src/components/RequestInspector.tsx
+++ b/frontend/src/components/RequestInspector.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Tabs from './Tabs';
+import { JSONTree } from 'react-json-tree';
 
 interface Props {
   request: {
@@ -21,13 +22,20 @@ const RequestInspector: React.FC<Props> = ({ request }) => {
       <h2 className="text-xl mb-2">Request {request.id}</h2>
       <Tabs tabs={['Raw', 'Headers', 'Body', 'Query Params', 'Cookies']} active={active} onChange={setActive} />
       {active === 'Raw' && (
-        <pre className="code-box whitespace-pre-wrap text-xs">{JSON.stringify(request, null, 2)}</pre>
+        <JSONTree data={request} hideRoot={true} />
       )}
       {active === 'Headers' && (
-        <pre className="code-box whitespace-pre-wrap text-xs">{JSON.stringify(request.headers, null, 2)}</pre>
+        <JSONTree data={request.headers} hideRoot={true} />
       )}
       {active === 'Body' && (
-        <pre className="code-box whitespace-pre-wrap text-xs">{request.body}</pre>
+        (() => {
+          try {
+            const parsed = JSON.parse(request.body);
+            return <JSONTree data={parsed} hideRoot={true} />;
+          } catch {
+            return <pre className="code-box whitespace-pre-wrap text-xs">{request.body}</pre>;
+          }
+        })()
       )}
       {active === 'Query Params' && (
         <pre className="code-box whitespace-pre-wrap text-xs">{Array.from(queryParams.entries()).map(([k,v]) => `${k}: ${v}`).join('\n') || 'None'}</pre>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -247,3 +247,6 @@ button:disabled {
 .mt-4 { margin-top: 1rem; }
 .table { width: 100%; border-collapse: collapse; }
 .table th, .table td { padding: 0.5rem; border-bottom: 1px solid #e5e7eb; }
+.endpoint-row td { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.group-header { text-align: center; padding: 0.5rem 0; background-color: #f3f4f6; }
+.mr-1 { margin-right: 0.25rem; }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -46,44 +46,76 @@ const DashboardPage: React.FC = () => {
     loadEndpoints();
   };
 
+  const toggleDisabled = async (id: number, disabled: boolean) => {
+    await fetch(`/api/endpoints/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ disabled })
+    });
+    loadEndpoints();
+  };
+
+  const deleteEndpoint = async (id: number) => {
+    await fetch(`/api/endpoints/${id}`, { method: 'DELETE' });
+    loadEndpoints();
+  };
+
   return (
     <div className="container">
       <h1 className="header">Dashboard</h1>
       <div className="mb-2 text-sm">
-        <Link to="/">Back to home</Link>
+        <Link to="/" className="btn">Back to home</Link>
       </div>
       <button className="btn mb-4" onClick={createEndpoint}>Create new endpoint</button>
       {loading ? <p>Loading...</p> : (
-        <table className="w-full text-left">
+        <table className="w-full text-left table">
           <thead>
-            <tr><th>UUID</th><th>Created</th></tr>
+            <tr><th>UUID</th><th>Created</th><th>Actions</th></tr>
           </thead>
           <tbody>
             {groups.today.length > 0 && (
-              <tr><th colSpan={2}>Today</th></tr>
+              <tr><th colSpan={3} className="group-header">Today</th></tr>
             )}
             {groups.today.map(e => (
-              <tr key={e.id}>
+              <tr key={e.id} className="endpoint-row">
                 <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
                 <td>{new Date(e.created_at).toLocaleString()}</td>
+                <td>
+                  <button className="btn mr-1" onClick={() => toggleDisabled(e.id, !e.disabled)}>
+                    {e.disabled ? 'Enable' : 'Disable'}
+                  </button>
+                  <button className="btn" onClick={() => deleteEndpoint(e.id)}>Delete</button>
+                </td>
               </tr>
             ))}
             {groups.yesterday.length > 0 && (
-              <tr><th colSpan={2}>Yesterday</th></tr>
+              <tr><th colSpan={3} className="group-header">Yesterday</th></tr>
             )}
             {groups.yesterday.map(e => (
-              <tr key={e.id}>
+              <tr key={e.id} className="endpoint-row">
                 <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
                 <td>{new Date(e.created_at).toLocaleString()}</td>
+                <td>
+                  <button className="btn mr-1" onClick={() => toggleDisabled(e.id, !e.disabled)}>
+                    {e.disabled ? 'Enable' : 'Disable'}
+                  </button>
+                  <button className="btn" onClick={() => deleteEndpoint(e.id)}>Delete</button>
+                </td>
               </tr>
             ))}
             {groups.older.length > 0 && (
-              <tr><th colSpan={2}>Older</th></tr>
+              <tr><th colSpan={3} className="group-header">Older</th></tr>
             )}
             {groups.older.map(e => (
-              <tr key={e.id}>
+              <tr key={e.id} className="endpoint-row">
                 <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
                 <td>{new Date(e.created_at).toLocaleString()}</td>
+                <td>
+                  <button className="btn mr-1" onClick={() => toggleDisabled(e.id, !e.disabled)}>
+                    {e.disabled ? 'Enable' : 'Disable'}
+                  </button>
+                  <button className="btn" onClick={() => deleteEndpoint(e.id)}>Delete</button>
+                </td>
               </tr>
             ))}
           </tbody>

--- a/frontend/src/pages/EndpointPage.tsx
+++ b/frontend/src/pages/EndpointPage.tsx
@@ -46,8 +46,8 @@ const EndpointPage: React.FC = () => {
   return (
     <div className="container" style={{maxWidth: '1200px'}}>
       <h1 className="header">Endpoint {uuid} <LiveIndicator /></h1>
-      <div className="mb-2 text-sm text-left">
-        <Link to="/">Back to home</Link>
+      <div className="mb-2 text-left">
+        <Link to="/" className="btn">Back to home</Link>
       </div>
       <div className="flex" style={{gap: '1rem', alignItems: 'flex-start'}}>
         <div style={{flex: '1'}}>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -17,8 +17,9 @@ const LandingPage: React.FC = () => {
       <button className="btn mb-4" onClick={createEndpoint}>Create new endpoint</button>
       <p className="mb-2">Example curl command:</p>
       <pre className="code-box">{`curl -X POST http://localhost:3000/<endpoint-id> -H "Content-Type: application/json" -d '{"hello":"world"}'`}</pre>
-      <div className="mt-4 text-sm">
-        <Link to="/dashboard">Go to dashboard</Link> | <Link to="/api-test">API tester</Link>
+      <div className="mt-4 space-x-2">
+        <Link to="/dashboard" className="btn">Dashboard</Link>
+        <Link to="/api-test" className="btn">API Tester</Link>
       </div>
     </div>
   );

--- a/frontend/src/pages/RequestPage.tsx
+++ b/frontend/src/pages/RequestPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { JSONTree } from 'react-json-tree';
 import { useParams } from 'react-router-dom';
 
 interface Req {
@@ -34,15 +35,20 @@ const RequestPage: React.FC = () => {
         </div>
         <div className="option-card text-left">
           <h2 className="font-semibold mb-1">Headers</h2>
-          <pre className="code-box whitespace-pre-wrap text-xs mb-2">
-{JSON.stringify(request.headers, null, 2)}
-          </pre>
+          <JSONTree data={request.headers} hideRoot={true} />
         </div>
         <div className="option-card text-left">
           <h2 className="font-semibold mb-1">Body</h2>
-          <pre className="code-box whitespace-pre-wrap text-xs">
-{request.body}
-          </pre>
+          {
+            (() => {
+              try {
+                const parsed = JSON.parse(request.body);
+                return <JSONTree data={parsed} hideRoot={true} />;
+              } catch {
+                return <pre className="code-box whitespace-pre-wrap text-xs">{request.body}</pre>;
+              }
+            })()
+          }
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow updating and deleting endpoints via API
- style nav buttons and group headers
- add pretty JSON viewer with react-json-tree
- show actions for each endpoint in dashboard
- include migration for `disabled` flag

## Testing
- `npm run build`
- `bin/rails db:migrate`
- `bundle exec rake` *(fails: Don't know how to build task 'default')*

------
https://chatgpt.com/codex/tasks/task_e_686e40c8398c832cbc095a7f8bf823f1