### PR TITLE
Improve endpoint management and request viewer

### DIFF
--- a/backend/app/controllers/api/endpoints_controller.rb
+++ b/backend/app/controllers/api/endpoints_controller.rb
@@ -22,7 +22,10 @@ class Api::EndpointsController < ApplicationController
 
   def destroy
     endpoint = Endpoint.find(params[:id])
-    endpoint.destroy!
-    head :no_content
+    if endpoint.destroy
+      head :no_content
+    else
+      render json: { error: endpoint.errors.full_messages.to_sentence }, status: :unprocessable_entity
+    end
   end
 end

--- a/backend/app/models/endpoint.rb
+++ b/backend/app/models/endpoint.rb
@@ -1,3 +1,14 @@
 class Endpoint < ApplicationRecord
   has_many :requests
+
+  before_destroy :ensure_no_requests
+
+  private
+
+  def ensure_no_requests
+    if requests.exists?
+      errors.add(:base, "Cannot delete endpoint with existing requests")
+      throw(:abort)
+    end
+  end
 end

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -250,3 +250,4 @@ button:disabled {
 .endpoint-row td { padding-top: 0.5rem; padding-bottom: 0.5rem; }
 .group-header { text-align: center; padding: 0.5rem 0; background-color: #f3f4f6; }
 .mr-1 { margin-right: 0.25rem; }
+.mr-2 { margin-right: 0.5rem; }

--- a/frontend/src/pages/ApiTesterPage.tsx
+++ b/frontend/src/pages/ApiTesterPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 
 const ApiTesterPage: React.FC = () => {
   const [testUrl, setTestUrl] = useState('');
@@ -82,7 +83,10 @@ const ApiTesterPage: React.FC = () => {
         onChange={e => setBodyText(e.target.value)}
         placeholder="Request body"
       />
-      <button onClick={testApi} className="btn">Send Request</button>
+      <div className="mb-2">
+        <button onClick={testApi} className="btn mr-2">Send Request</button>
+        <Link to="/" className="btn">Back to home</Link>
+      </div>
       {testResult && (
         <div className="status mt-2">
           <p>Status: {testResult.status}</p>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -47,6 +47,7 @@ const DashboardPage: React.FC = () => {
   };
 
   const toggleDisabled = async (id: number, disabled: boolean) => {
+    if (!window.confirm(`Are you sure you want to ${disabled ? 'disable' : 'enable'} this endpoint?`)) return;
     await fetch(`/api/endpoints/${id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -56,7 +57,12 @@ const DashboardPage: React.FC = () => {
   };
 
   const deleteEndpoint = async (id: number) => {
-    await fetch(`/api/endpoints/${id}`, { method: 'DELETE' });
+    if (!window.confirm('Are you sure you want to delete this endpoint?')) return;
+    const res = await fetch(`/api/endpoints/${id}`, { method: 'DELETE' });
+    if (!res.ok) {
+      const data = await res.json();
+      alert(data.error || 'Failed to delete endpoint');
+    }
     loadEndpoints();
   };
 

--- a/frontend/src/pages/RequestPage.tsx
+++ b/frontend/src/pages/RequestPage.tsx
@@ -13,6 +13,9 @@ interface Req {
 const RequestPage: React.FC = () => {
   const { id } = useParams();
   const [request, setRequest] = useState<Req | null>(null);
+  const [showRaw, setShowRaw] = useState(true);
+  const [showHeaders, setShowHeaders] = useState(true);
+  const [showBody, setShowBody] = useState(true);
 
   useEffect(() => {
     const loadRequest = async () => {
@@ -33,13 +36,29 @@ const RequestPage: React.FC = () => {
           <h2 className="font-semibold mb-1">General</h2>
           <div className="font-mono text-sm">{request.method} - {request.created_at}</div>
         </div>
+
         <div className="option-card text-left">
-          <h2 className="font-semibold mb-1">Headers</h2>
-          <JSONTree data={request.headers} hideRoot={true} />
+          <div className="flex justify-between mb-1">
+            <h2 className="font-semibold">Raw</h2>
+            <button className="btn mr-2" onClick={() => setShowRaw(!showRaw)}>{showRaw ? 'Collapse' : 'Expand'}</button>
+          </div>
+          {showRaw && <JSONTree data={request} hideRoot={true} />}
         </div>
+
         <div className="option-card text-left">
-          <h2 className="font-semibold mb-1">Body</h2>
-          {
+          <div className="flex justify-between mb-1">
+            <h2 className="font-semibold">Headers</h2>
+            <button className="btn mr-2" onClick={() => setShowHeaders(!showHeaders)}>{showHeaders ? 'Collapse' : 'Expand'}</button>
+          </div>
+          {showHeaders && <JSONTree data={request.headers} hideRoot={true} />}
+        </div>
+
+        <div className="option-card text-left">
+          <div className="flex justify-between mb-1">
+            <h2 className="font-semibold">Body</h2>
+            <button className="btn mr-2" onClick={() => setShowBody(!showBody)}>{showBody ? 'Collapse' : 'Expand'}</button>
+          </div>
+          {showBody && (
             (() => {
               try {
                 const parsed = JSON.parse(request.body);
@@ -48,7 +67,7 @@ const RequestPage: React.FC = () => {
                 return <pre className="code-box whitespace-pre-wrap text-xs">{request.body}</pre>;
               }
             })()
-          }
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- prevent deleting endpoints with requests
- show API errors when deletion fails
- confirm disable/delete actions
- enable collapse controls on Request page data
- show Back to home link on API tester and style buttons

## Testing
- `npm run build`
- `bundle install`


------
https://chatgpt.com/codex/tasks/task_e_686e451ebb00832c96277a6d6af01594