### PR TITLE
Improve button consistency and JSON display

### DIFF
--- a/backend/app/controllers/api/endpoints_controller.rb
+++ b/backend/app/controllers/api/endpoints_controller.rb
@@ -1,7 +1,7 @@
 class Api::EndpointsController < ApplicationController
   def index
-    endpoints = Endpoint.order(created_at: :desc)
-    render json: endpoints
+    endpoints = Endpoint.includes(:requests).order(created_at: :desc)
+    render json: endpoints.as_json(methods: [:can_delete, :delete_reason])
   end
 
   def create
@@ -11,7 +11,7 @@ class Api::EndpointsController < ApplicationController
 
   def show_by_uuid
     endpoint = Endpoint.find_by!(uuid: params[:uuid])
-    render json: { id: endpoint.id, uuid: endpoint.uuid }
+    render json: endpoint.as_json(methods: [:can_delete, :delete_reason])
   end
 
   def update

--- a/backend/app/controllers/api/requests_controller.rb
+++ b/backend/app/controllers/api/requests_controller.rb
@@ -11,7 +11,7 @@ class Api::RequestsController < ApplicationController
   end
 
   def create
-    req = @endpoint.requests.create!(method: params[:method], headers: params[:headers], body: params[:body])
+    req = @endpoint.requests.create!(method: params[:method], headers: params[:headers].to_json, body: params[:body])
     render json: req, status: :created
   end
 

--- a/backend/app/controllers/capture_controller.rb
+++ b/backend/app/controllers/capture_controller.rb
@@ -1,9 +1,10 @@
 class CaptureController < ActionController::API
   def receive
     endpoint = Endpoint.find_by!(uuid: params[:uuid])
+    headers = request.headers.to_h.select { |k, _| k.start_with?("HTTP_") }
     req = endpoint.requests.create!(
       method: request.method,
-      headers: request.headers.to_h.select { |k, _| k.start_with?("HTTP_") },
+      headers: headers.to_json,
       body: request.raw_post
     )
 

--- a/backend/app/models/endpoint.rb
+++ b/backend/app/models/endpoint.rb
@@ -3,6 +3,14 @@ class Endpoint < ApplicationRecord
 
   before_destroy :ensure_no_requests
 
+  def can_delete
+    requests.none?
+  end
+
+  def delete_reason
+    can_delete ? nil : 'Cannot delete endpoint with existing requests'
+  end
+
   private
 
   def ensure_no_requests

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -31,6 +31,8 @@ body {
   border-radius: 4px;
   cursor: pointer;
   display: inline-block;
+  font-size: 1rem;
+  text-decoration: none;
 }
 
 .btn:hover {
@@ -251,3 +253,15 @@ button:disabled {
 .group-header { text-align: center; padding: 0.5rem 0; background-color: #f3f4f6; }
 .mr-1 { margin-right: 0.25rem; }
 .mr-2 { margin-right: 0.5rem; }
+.help-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-left: 0.25rem;
+  font-size: 12px;
+  border: 1px solid #6b7280;
+  border-radius: 50%;
+  cursor: default;
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,6 +5,9 @@ interface Endpoint {
   id: number;
   uuid: string;
   created_at: string;
+  disabled: boolean;
+  can_delete: boolean;
+  delete_reason: string | null;
 }
 
 const DashboardPage: React.FC = () => {
@@ -90,7 +93,8 @@ const DashboardPage: React.FC = () => {
                   <button className="btn mr-1" onClick={() => toggleDisabled(e.id, !e.disabled)}>
                     {e.disabled ? 'Enable' : 'Disable'}
                   </button>
-                  <button className="btn" onClick={() => deleteEndpoint(e.id)}>Delete</button>
+                  <button className="btn" disabled={!e.can_delete} onClick={() => deleteEndpoint(e.id)}>Delete</button>
+                  {!e.can_delete && <span className="help-icon" title={e.delete_reason || ''}>?</span>}
                 </td>
               </tr>
             ))}
@@ -105,7 +109,8 @@ const DashboardPage: React.FC = () => {
                   <button className="btn mr-1" onClick={() => toggleDisabled(e.id, !e.disabled)}>
                     {e.disabled ? 'Enable' : 'Disable'}
                   </button>
-                  <button className="btn" onClick={() => deleteEndpoint(e.id)}>Delete</button>
+                  <button className="btn" disabled={!e.can_delete} onClick={() => deleteEndpoint(e.id)}>Delete</button>
+                  {!e.can_delete && <span className="help-icon" title={e.delete_reason || ''}>?</span>}
                 </td>
               </tr>
             ))}
@@ -120,7 +125,8 @@ const DashboardPage: React.FC = () => {
                   <button className="btn mr-1" onClick={() => toggleDisabled(e.id, !e.disabled)}>
                     {e.disabled ? 'Enable' : 'Disable'}
                   </button>
-                  <button className="btn" onClick={() => deleteEndpoint(e.id)}>Delete</button>
+                  <button className="btn" disabled={!e.can_delete} onClick={() => deleteEndpoint(e.id)}>Delete</button>
+                  {!e.can_delete && <span className="help-icon" title={e.delete_reason || ''}>?</span>}
                 </td>
               </tr>
             ))}

--- a/frontend/src/pages/RequestPage.tsx
+++ b/frontend/src/pages/RequestPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { JSONTree } from 'react-json-tree';
 import { useParams } from 'react-router-dom';
 
@@ -16,6 +16,19 @@ const RequestPage: React.FC = () => {
   const [showRaw, setShowRaw] = useState(true);
   const [showHeaders, setShowHeaders] = useState(true);
   const [showBody, setShowBody] = useState(true);
+
+  const parsedHeaders = useMemo(() => {
+    if (!request) return null;
+    if (typeof request.headers === 'string') {
+      try { return JSON.parse(request.headers); } catch { return null; }
+    }
+    return request.headers;
+  }, [request]);
+
+  const parsedBody = useMemo(() => {
+    if (!request) return null;
+    try { return JSON.parse(request.body); } catch { return null; }
+  }, [request]);
 
   useEffect(() => {
     const loadRequest = async () => {
@@ -42,7 +55,9 @@ const RequestPage: React.FC = () => {
             <h2 className="font-semibold">Raw</h2>
             <button className="btn mr-2" onClick={() => setShowRaw(!showRaw)}>{showRaw ? 'Collapse' : 'Expand'}</button>
           </div>
-          {showRaw && <JSONTree data={request} hideRoot={true} />}
+          {showRaw && (
+            <JSONTree data={{ ...request, headers: parsedHeaders || request.headers, body: parsedBody || request.body }} hideRoot={true} />
+          )}
         </div>
 
         <div className="option-card text-left">
@@ -50,7 +65,9 @@ const RequestPage: React.FC = () => {
             <h2 className="font-semibold">Headers</h2>
             <button className="btn mr-2" onClick={() => setShowHeaders(!showHeaders)}>{showHeaders ? 'Collapse' : 'Expand'}</button>
           </div>
-          {showHeaders && <JSONTree data={request.headers} hideRoot={true} />}
+          {showHeaders && (
+            parsedHeaders ? <JSONTree data={parsedHeaders} hideRoot={true} /> : <pre className="code-box whitespace-pre-wrap text-xs">{request.headers}</pre>
+          )}
         </div>
 
         <div className="option-card text-left">
@@ -59,14 +76,7 @@ const RequestPage: React.FC = () => {
             <button className="btn mr-2" onClick={() => setShowBody(!showBody)}>{showBody ? 'Collapse' : 'Expand'}</button>
           </div>
           {showBody && (
-            (() => {
-              try {
-                const parsed = JSON.parse(request.body);
-                return <JSONTree data={parsed} hideRoot={true} />;
-              } catch {
-                return <pre className="code-box whitespace-pre-wrap text-xs">{request.body}</pre>;
-              }
-            })()
+            parsedBody ? <JSONTree data={parsedBody} hideRoot={true} /> : <pre className="code-box whitespace-pre-wrap text-xs">{request.body}</pre>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- ensure button styles are uniform
- add helper icon styling
- disable Delete when endpoint can't be removed
- parse headers/body JSON and make sections collapsible
- expose deletion info from the API and store headers as JSON

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e47f54770832cb6c997c7c3ffb294