### PR TITLE
Enhance dashboard and search features

### DIFF
--- a/backend/app/controllers/api/endpoints_controller.rb
+++ b/backend/app/controllers/api/endpoints_controller.rb
@@ -5,8 +5,8 @@ class Api::EndpointsController < ApplicationController
   end
 
   def create
-    endpoint = Endpoint.create!(uuid: SecureRandom.uuid)
-    render json: { id: endpoint.id, uuid: endpoint.uuid }
+    endpoint = Endpoint.create!(uuid: SecureRandom.uuid, expires_at: params[:expires_at])
+    render json: { id: endpoint.id, uuid: endpoint.uuid, expires_at: endpoint.expires_at }
   end
 
   def show_by_uuid

--- a/backend/db/migrate/20250710120000_add_expires_at_to_endpoints.rb
+++ b/backend/db/migrate/20250710120000_add_expires_at_to_endpoints.rb
@@ -1,0 +1,5 @@
+class AddExpiresAtToEndpoints < ActiveRecord::Migration[8.0]
+  def change
+    add_column :endpoints, :expires_at, :datetime
+  end
+end

--- a/frontend/src/components/RequestInspector.tsx
+++ b/frontend/src/components/RequestInspector.tsx
@@ -41,13 +41,15 @@ const RequestInspector: React.FC<Props> = ({ request }) => {
       <h2 className="text-xl mb-2">Request {request.id}</h2>
       <Tabs tabs={['Raw', 'Headers', 'Body', 'Query Params', 'Cookies']} active={active} onChange={setActive} />
       {active === 'Raw' && (
-        <JSONTree data={{ ...request, headers: parsedHeaders || request.headers, body: parsedBody || request.body }} hideRoot={true} />
+        <div className="json-tree">
+          <JSONTree data={{ ...request, headers: parsedHeaders || request.headers, body: parsedBody || request.body }} hideRoot={true} />
+        </div>
       )}
       {active === 'Headers' && (
-        parsedHeaders ? <JSONTree data={parsedHeaders} hideRoot={true} /> : <pre className="code-box whitespace-pre-wrap text-xs">{request.headers}</pre>
+        parsedHeaders ? <div className="json-tree"><JSONTree data={parsedHeaders} hideRoot={true} /></div> : <pre className="code-box whitespace-pre-wrap text-xs">{request.headers}</pre>
       )}
       {active === 'Body' && (
-        parsedBody ? <JSONTree data={parsedBody} hideRoot={true} /> : <pre className="code-box whitespace-pre-wrap text-xs">{request.body}</pre>
+        parsedBody ? <div className="json-tree"><JSONTree data={parsedBody} hideRoot={true} /></div> : <pre className="code-box whitespace-pre-wrap text-xs">{request.body}</pre>
       )}
       {active === 'Query Params' && (
         <pre className="code-box whitespace-pre-wrap text-xs">{Array.from(queryParams.entries()).map(([k,v]) => `${k}: ${v}`).join('\n') || 'None'}</pre>

--- a/frontend/src/components/RequestList.tsx
+++ b/frontend/src/components/RequestList.tsx
@@ -5,15 +5,17 @@ interface Props {
   requests: Req[];
   activeId: number | null;
   onSelect: (r: Req) => void;
+  highlight?: string;
 }
 
-const RequestList: React.FC<Props> = ({ requests, activeId, onSelect }) => (
+const RequestList: React.FC<Props> = ({ requests, activeId, onSelect, highlight }) => (
   <ul className="space-y-2 request-list text-left">
     {requests.map(r => (
       <RequestListItem
         key={r.id}
         request={r}
         active={r.id === activeId}
+        highlight={highlight}
         onClick={() => onSelect(r)}
       />
     ))}

--- a/frontend/src/components/RequestListItem.tsx
+++ b/frontend/src/components/RequestListItem.tsx
@@ -12,21 +12,32 @@ interface Props {
   request: Req;
   onClick: () => void;
   active: boolean;
+  highlight?: string;
 }
 
-const RequestListItem: React.FC<Props> = ({ request, onClick, active }) => (
-  <li
-    className={active ? 'request-item active' : 'request-item'}
-    onClick={onClick}
-  >
-    <div className="flex justify-between">
-      <span className="font-mono text-sm">{request.method}</span>
-      <span className="text-xs">{new Date(request.created_at).toLocaleTimeString()}</span>
-    </div>
-    <pre className="code-box whitespace-pre-wrap text-xs mt-1">
-      {request.body.slice(0, 80)}
-    </pre>
-  </li>
-);
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const RequestListItem: React.FC<Props> = ({ request, onClick, active, highlight }) => {
+  const snippet = request.body.slice(0, 80);
+  let content: string = snippet;
+  if (highlight) {
+    try {
+      const regex = new RegExp(escapeRegExp(highlight), 'gi');
+      content = snippet.replace(regex, match => `<mark>${match}</mark>`);
+    } catch {}
+  }
+  return (
+    <li
+      className={active ? 'request-item active' : 'request-item'}
+      onClick={onClick}
+    >
+      <div className="flex justify-between">
+        <span className="font-mono text-sm">{request.method}</span>
+        <span className="text-xs">{new Date(request.created_at).toLocaleTimeString()}</span>
+      </div>
+      <pre className="code-box whitespace-pre-wrap text-xs mt-1" dangerouslySetInnerHTML={{ __html: content }} />
+    </li>
+  );
+};
 
 export default RequestListItem;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -120,6 +120,7 @@ button:disabled {
   border-radius: 4px;
   font-size: 0.85rem;
   overflow-x: auto;
+  text-align: left;
 }
 .mb-2 { margin-bottom: 0.5rem; }
 .mb-4 { margin-bottom: 1rem; }
@@ -223,6 +224,7 @@ button:disabled {
   border-radius: 8px;
   box-shadow: 0 1px 4px rgba(0,0,0,0.1);
   background-color: #fff;
+  text-align: left;
 }
 .request-item {
   border: 1px solid #e5e7eb;
@@ -264,4 +266,29 @@ button:disabled {
   border: 1px solid #6b7280;
   border-radius: 50%;
   cursor: default;
+  position: relative;
+}
+
+.help-icon .tooltip {
+  display: none;
+  position: absolute;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #374151;
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  font-size: 12px;
+  z-index: 10;
+}
+
+.help-icon:hover .tooltip {
+  display: block;
+}
+
+.json-tree {
+  text-align: left;
+  font-family: monospace;
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ interface Endpoint {
   id: number;
   uuid: string;
   created_at: string;
+  expires_at: string | null;
   disabled: boolean;
   can_delete: boolean;
   delete_reason: string | null;
@@ -13,6 +14,7 @@ interface Endpoint {
 const DashboardPage: React.FC = () => {
   const [endpoints, setEndpoints] = useState<Endpoint[]>([]);
   const [loading, setLoading] = useState(false);
+  const [expiresAt, setExpiresAt] = useState('');
 
   const loadEndpoints = async () => {
     setLoading(true);
@@ -45,7 +47,12 @@ const DashboardPage: React.FC = () => {
   }, [endpoints]);
 
   const createEndpoint = async () => {
-    await fetch('/api/endpoints', { method: 'POST' });
+    await fetch('/api/endpoints', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ expires_at: expiresAt || null })
+    });
+    setExpiresAt('');
     loadEndpoints();
   };
 
@@ -75,58 +82,85 @@ const DashboardPage: React.FC = () => {
       <div className="mb-2 text-sm">
         <Link to="/" className="btn">Back to home</Link>
       </div>
-      <button className="btn mb-4" onClick={createEndpoint}>Create new endpoint</button>
+      <div className="mb-4 flex" style={{gap: '0.5rem', alignItems: 'center'}}>
+        <input
+          type="datetime-local"
+          className="url-box"
+          value={expiresAt}
+          onChange={e => setExpiresAt(e.target.value)}
+          placeholder="Expiry (optional)"
+        />
+        <button className="btn" onClick={createEndpoint}>Create new endpoint</button>
+      </div>
       {loading ? <p>Loading...</p> : (
         <table className="w-full text-left table">
           <thead>
-            <tr><th>UUID</th><th>Created</th><th>Actions</th></tr>
+            <tr><th>UUID</th><th>Created</th><th>Expires</th><th>Actions</th></tr>
           </thead>
           <tbody>
             {groups.today.length > 0 && (
-              <tr><th colSpan={3} className="group-header">Today</th></tr>
+            <tr><th colSpan={4} className="group-header">Today</th></tr>
             )}
             {groups.today.map(e => (
               <tr key={e.id} className="endpoint-row">
                 <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
                 <td>{new Date(e.created_at).toLocaleString()}</td>
+                <td>{e.expires_at ? new Date(e.expires_at).toLocaleString() : 'None'}</td>
                 <td>
                   <button className="btn mr-1" onClick={() => toggleDisabled(e.id, !e.disabled)}>
                     {e.disabled ? 'Enable' : 'Disable'}
                   </button>
                   <button className="btn" disabled={!e.can_delete} onClick={() => deleteEndpoint(e.id)}>Delete</button>
-                  {!e.can_delete && <span className="help-icon" title={e.delete_reason || ''}>?</span>}
+                  {!e.can_delete && (
+                    <span className="help-icon">
+                      ?
+                      <span className="tooltip">{e.delete_reason}</span>
+                    </span>
+                  )}
                 </td>
               </tr>
             ))}
             {groups.yesterday.length > 0 && (
-              <tr><th colSpan={3} className="group-header">Yesterday</th></tr>
+            <tr><th colSpan={4} className="group-header">Yesterday</th></tr>
             )}
             {groups.yesterday.map(e => (
               <tr key={e.id} className="endpoint-row">
                 <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
                 <td>{new Date(e.created_at).toLocaleString()}</td>
+                <td>{e.expires_at ? new Date(e.expires_at).toLocaleString() : 'None'}</td>
                 <td>
                   <button className="btn mr-1" onClick={() => toggleDisabled(e.id, !e.disabled)}>
                     {e.disabled ? 'Enable' : 'Disable'}
                   </button>
                   <button className="btn" disabled={!e.can_delete} onClick={() => deleteEndpoint(e.id)}>Delete</button>
-                  {!e.can_delete && <span className="help-icon" title={e.delete_reason || ''}>?</span>}
+                  {!e.can_delete && (
+                    <span className="help-icon">
+                      ?
+                      <span className="tooltip">{e.delete_reason}</span>
+                    </span>
+                  )}
                 </td>
               </tr>
             ))}
             {groups.older.length > 0 && (
-              <tr><th colSpan={3} className="group-header">Older</th></tr>
+            <tr><th colSpan={4} className="group-header">Older</th></tr>
             )}
             {groups.older.map(e => (
               <tr key={e.id} className="endpoint-row">
                 <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
                 <td>{new Date(e.created_at).toLocaleString()}</td>
+                <td>{e.expires_at ? new Date(e.expires_at).toLocaleString() : 'None'}</td>
                 <td>
                   <button className="btn mr-1" onClick={() => toggleDisabled(e.id, !e.disabled)}>
                     {e.disabled ? 'Enable' : 'Disable'}
                   </button>
                   <button className="btn" disabled={!e.can_delete} onClick={() => deleteEndpoint(e.id)}>Delete</button>
-                  {!e.can_delete && <span className="help-icon" title={e.delete_reason || ''}>?</span>}
+                  {!e.can_delete && (
+                    <span className="help-icon">
+                      ?
+                      <span className="tooltip">{e.delete_reason}</span>
+                    </span>
+                  )}
                 </td>
               </tr>
             ))}

--- a/frontend/src/pages/EndpointPage.tsx
+++ b/frontend/src/pages/EndpointPage.tsx
@@ -51,7 +51,7 @@ const EndpointPage: React.FC = () => {
       </div>
       <div className="flex" style={{gap: '1rem', alignItems: 'flex-start'}}>
         <div style={{flex: '1'}}>
-          <div className="mb-2 flex" style={{gap: '0.5rem'}}>
+          <div className="mb-2 flex" style={{gap: '0.5rem', alignItems: 'center'}}>
             <select className="url-box" value={methodFilter} onChange={e => setMethodFilter(e.target.value)}>
               <option value="">All methods</option>
               <option value="GET">GET</option>
@@ -61,11 +61,19 @@ const EndpointPage: React.FC = () => {
               <option value="DELETE">DELETE</option>
             </select>
             <SearchInput value={search} onChange={setSearch} />
+            {search && (
+              <span className="text-sm">{filtered.length} {filtered.length === 1 ? 'match' : 'matches'}</span>
+            )}
           </div>
           {filtered.length === 0 ? (
             <p>No requests yet.</p>
           ) : (
-            <RequestList requests={filtered} activeId={selected?.id || null} onSelect={setSelected} />
+            <RequestList
+              requests={filtered}
+              activeId={selected?.id || null}
+              onSelect={setSelected}
+              highlight={search}
+            />
           )}
         </div>
         <div style={{flex: '1'}}>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -3,9 +3,14 @@ import { useNavigate, Link } from 'react-router-dom';
 
 const LandingPage: React.FC = () => {
   const navigate = useNavigate();
+  const [expiresAt, setExpiresAt] = React.useState('');
 
   const createEndpoint = async () => {
-    const res = await fetch('/api/endpoints', { method: 'POST' });
+    const res = await fetch('/api/endpoints', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ expires_at: expiresAt || null })
+    });
     const data = await res.json();
     navigate(`/endpoint/${data.uuid}`);
   };
@@ -14,7 +19,16 @@ const LandingPage: React.FC = () => {
     <div className="container">
       <h1 className="header">Webhook Mirror</h1>
       <p className="mb-4">Capture and inspect HTTP requests in real time.</p>
-      <button className="btn mb-4" onClick={createEndpoint}>Create new endpoint</button>
+      <div className="mb-4 flex" style={{gap: '0.5rem', alignItems: 'center'}}>
+        <input
+          type="datetime-local"
+          className="url-box"
+          value={expiresAt}
+          onChange={e => setExpiresAt(e.target.value)}
+          placeholder="Expiry (optional)"
+        />
+        <button className="btn" onClick={createEndpoint}>Create new endpoint</button>
+      </div>
       <p className="mb-2">Example curl command:</p>
       <pre className="code-box">{`curl -X POST http://localhost:3000/<endpoint-id> -H "Content-Type: application/json" -d '{"hello":"world"}'`}</pre>
       <div className="mt-4 space-x-2">

--- a/frontend/src/pages/WebhookPage.tsx
+++ b/frontend/src/pages/WebhookPage.tsx
@@ -15,6 +15,7 @@ const WebhookPage: React.FC = () => {
   const [curlUrl, setCurlUrl] = useState('');
   const [endpointId, setEndpointId] = useState<number | null>(null);
   const [requests, setRequests] = useState<Req[]>([]);
+  const [expiresAt, setExpiresAt] = useState('');
 
   const [apiStatus, setApiStatus] = useState<string | null>(null);
   const [apiHeaders, setApiHeaders] = useState<Record<string, string> | null>(null);
@@ -25,7 +26,11 @@ const WebhookPage: React.FC = () => {
     setApiStatus(null);
     setApiHeaders(null);
     try {
-      const res = await fetch('/api/endpoints', { method: 'POST' });
+      const res = await fetch('/api/endpoints', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ expires_at: expiresAt || null })
+      });
       const data = await res.json();
       const { protocol, hostname, origin } = window.location;
       // Display URLs should use the current origin (5173 when running locally)
@@ -88,9 +93,18 @@ const WebhookPage: React.FC = () => {
           <pre className="code-box">{`curl ${curlUrl}`}</pre>
         </div>
       )}
-      <button onClick={createEndpoint} disabled={loading} className="btn">
-        {loading && <span className="loading-spinner" />} {loading ? 'Creating...' : 'Generate URL'}
-      </button>
+      <div className="mb-2 flex" style={{gap: '0.5rem', alignItems: 'center'}}>
+        <input
+          type="datetime-local"
+          className="url-box"
+          value={expiresAt}
+          onChange={e => setExpiresAt(e.target.value)}
+          placeholder="Expiry (optional)"
+        />
+        <button onClick={createEndpoint} disabled={loading} className="btn">
+          {loading && <span className="loading-spinner" />} {loading ? 'Creating...' : 'Generate URL'}
+        </button>
+      </div>
       {apiStatus && (
         <div className="status">
           <p>{apiStatus}</p>


### PR DESCRIPTION
## Summary
- allow setting endpoint expiry dates via UI and API
- show delete button tooltip
- tweak JSON viewer alignment
- display match counts and highlight matches when searching requests

## Testing
- `npm run build`
- `bundle install`
- `bundle exec rake test` *(fails: Don't know how to build task)*

------
https://chatgpt.com/codex/tasks/task_e_686e4afc3c84832c813237d6ffcc9ef4