### PR TITLE
Fix inspector types and layout styling

### DIFF
--- a/frontend/src/components/RequestListItem.tsx
+++ b/frontend/src/components/RequestListItem.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 export interface Req {
   id: number;
   method: string;
-  headers: Record<string, string>;
+  headers: Record<string, string> | string;
   body: string;
   created_at: string;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,7 +8,7 @@ body {
 
 .container {
   padding: 2rem;
-  max-width: 800px;
+  max-width: 1000px;
   margin: 2rem auto;
   text-align: center;
   background: #fff;
@@ -141,6 +141,7 @@ button:disabled {
 .p-2 { padding: 0.5rem; }
 .p-3 { padding: 0.75rem; }
 .p-8 { padding: 2rem; }
+.space-x-2 > * + * { margin-left: 0.5rem; }
 .space-y-2 > * + * { margin-top: 0.5rem; }
 .space-y-1 > * + * { margin-top: 0.25rem; }
 .space-y-4 > * + * { margin-top: 1rem; }

--- a/frontend/src/pages/RequestPage.tsx
+++ b/frontend/src/pages/RequestPage.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'react-router-dom';
 interface Req {
   id: number;
   method: string;
-  headers: Record<string, string>;
+  headers: Record<string, string> | string;
   body: string;
   created_at: string;
 }
@@ -21,6 +21,13 @@ const RequestPage: React.FC = () => {
     if (!request) return null;
     if (typeof request.headers === 'string') {
       try { return JSON.parse(request.headers); } catch { return null; }
+    }
+    return request.headers;
+  }, [request]);
+  const headersObj = useMemo(() => {
+    if (!request) return {} as Record<string, string>;
+    if (typeof request.headers === 'string') {
+      try { return JSON.parse(request.headers); } catch { return {}; }
     }
     return request.headers;
   }, [request]);
@@ -56,7 +63,7 @@ const RequestPage: React.FC = () => {
             <button className="btn mr-2" onClick={() => setShowRaw(!showRaw)}>{showRaw ? 'Collapse' : 'Expand'}</button>
           </div>
           {showRaw && (
-            <JSONTree data={{ ...request, headers: parsedHeaders || request.headers, body: parsedBody || request.body }} hideRoot={true} />
+            <JSONTree data={{ ...request, headers: parsedHeaders || headersObj, body: parsedBody || request.body }} hideRoot={true} />
           )}
         </div>
 
@@ -66,7 +73,15 @@ const RequestPage: React.FC = () => {
             <button className="btn mr-2" onClick={() => setShowHeaders(!showHeaders)}>{showHeaders ? 'Collapse' : 'Expand'}</button>
           </div>
           {showHeaders && (
-            parsedHeaders ? <JSONTree data={parsedHeaders} hideRoot={true} /> : <pre className="code-box whitespace-pre-wrap text-xs">{request.headers}</pre>
+            parsedHeaders ? (
+              <JSONTree data={parsedHeaders} hideRoot={true} />
+            ) : (
+              <pre className="code-box whitespace-pre-wrap text-xs">{
+                typeof request.headers === 'string'
+                  ? request.headers
+                  : JSON.stringify(request.headers, null, 2)
+              }</pre>
+            )
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- widen page layout and add horizontal spacing utility
- handle string JSON for headers when viewing request inspector
- support string headers type across request components

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e4ea79a58832c82df7223511e5e41