### PR TITLE
Center layout fixes for landing page and request search

### DIFF
--- a/frontend/src/pages/EndpointPage.tsx
+++ b/frontend/src/pages/EndpointPage.tsx
@@ -61,10 +61,12 @@ const EndpointPage: React.FC = () => {
               <option value="DELETE">DELETE</option>
             </select>
             <SearchInput value={search} onChange={setSearch} />
-            {search && (
-              <span className="text-sm">{filtered.length} {filtered.length === 1 ? 'match' : 'matches'}</span>
-            )}
           </div>
+          {search && (
+            <div className="mb-2 text-left">
+              <span className="text-sm">{filtered.length} {filtered.length === 1 ? 'match' : 'matches'}</span>
+            </div>
+          )}
           {filtered.length === 0 ? (
             <p>No requests yet.</p>
           ) : (

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -25,12 +25,16 @@ const LandingPage: React.FC = () => {
     <div className="container">
       <h1 className="header">Webhook Mirror</h1>
       <p className="mb-4">Capture and inspect HTTP requests in real time.</p>
-      <div className="mb-4 flex" style={{gap: '0.5rem', alignItems: 'center'}}>
-        <div className="text-left">
+      <div
+        className="mb-4 flex"
+        style={{ gap: '0.5rem', alignItems: 'center', justifyContent: 'center' }}
+      >
+        <div>
           <label className="block mb-1">Select expiry time</label>
           <input
             type="datetime-local"
             className="url-box"
+            style={{ width: '220px' }}
             value={expiresAt}
             onChange={e => setExpiresAt(e.target.value)}
             placeholder="Expiry (optional)"


### PR DESCRIPTION
## Summary
- center the expiry selector and create button on the landing page
- show search match count below the filter bar

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e54deaa7c832c95093146bd59ad8a