### PR TITLE
Integrate neetoUI into frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,10 +9,16 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@babel/runtime": "^7.27.6",
+    "@bigbinary/neetoui": "^8.2.60",
+    "formik": "^2.4.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-json-tree": "^0.20.0",
-    "react-router-dom": "^6.23.0"
+    "react-router-dom": "^6.23.0",
+    "react-toastify": "^11.0.5",
+    "sass": "^1.89.2",
+    "yup": "^1.6.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1,3 +1,5 @@
+@import "@bigbinary/neetoui/dist/index.css";
+@import "react-toastify/dist/ReactToastify.min.css";
 body {
   font-family: Arial, sans-serif;
   margin: 0;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,10 +7,12 @@ import WebhookPage from './pages/WebhookPage';
 import ApiTesterPage from './pages/ApiTesterPage';
 import EndpointPage from './pages/EndpointPage';
 import RequestPage from './pages/RequestPage';
-import './index.css';
+import './index.scss';
+import { ToastContainer } from 'react-toastify';
 
 const App = () => (
   <BrowserRouter>
+    <ToastContainer />
     <Routes>
       <Route path="/" element={<LandingPage />} />
       <Route path="/dashboard" element={<DashboardPage />} />

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { Button, Tooltip } from '@bigbinary/neetoui';
+import * as NeetoUI from '@bigbinary/neetoui';
+import { Form, Input, Button as FormButton } from '@bigbinary/neetoui/formik';
+import * as Yup from 'yup';
 
 const LandingPage: React.FC = () => {
   const navigate = useNavigate();
   const [expiresAt, setExpiresAt] = React.useState('');
+  const componentName = 'Badge';
+  const DynamicComponent = (NeetoUI as any)[componentName];
 
   const createEndpoint = async () => {
     try {
@@ -47,6 +53,33 @@ const LandingPage: React.FC = () => {
       <div className="mt-4 space-x-2">
         <Link to="/dashboard" className="btn">Dashboard</Link>
         <Link to="/api-test" className="btn">API Tester</Link>
+      </div>
+
+      <div className="mt-4 space-y-2">
+        <Tooltip content="I am a tooltip">
+          <span>Hover me</span>
+        </Tooltip>
+        <Button label="Click me" style="primary" onClick={() => console.log('clicked')} />
+        {DynamicComponent && <DynamicComponent label="Dynamic!" />}
+
+        <Form
+          formikProps={{
+            initialValues: { name: '', email: '' },
+            validationSchema: Yup.object({
+              name: Yup.string().required('Name is required'),
+              email: Yup.string().email('Invalid email').required('Email is required'),
+            }),
+            onSubmit: values => console.log(values),
+          }}
+        >
+          {(props) => (
+            <>
+              <Input {...props} label="Name" name="name" />
+              <Input {...props} label="Email" name="email" />
+              <FormButton label="Submit" type="submit" style="primary" />
+            </>
+          )}
+        </Form>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add neetoUI dependencies and Toastify peers
- include neetoUI styles and Toastify CSS
- render ToastContainer in App
- show basic neetoUI components and form example on landing page
- import neetoUI via wildcard for dynamic component demo

## Testing
- `bundle install --path vendor/bundle`
- `bin/rails db:prepare`
- `npm install --legacy-peer-deps`
- `npm run build` *(fails: Rollup can't resolve some peer deps)*

------
https://chatgpt.com/codex/tasks/task_e_686e58749160832ca3906d5123803c67