### PR TITLE
Fix neetoui stylesheet import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Open a new terminal and run:
 
 ```bash
 cd frontend
-npm install           # install JavaScript dependencies
-npm run dev           # start Vite dev server on http://localhost:5173
+yarn config set nodeLinker node-modules  # ensure packages install into node_modules
+yarn install          # install JavaScript dependencies
+yarn dev              # start Vite dev server on http://localhost:5173
 ```
 
 With both servers running you can browse to `http://localhost:5173` to use the application while it interacts with the Rails API running on port 3000.

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1,4 +1,3 @@
-@import "@bigbinary/neetoui/dist/index.css";
 @import "react-toastify/dist/ReactToastify.min.css";
 body {
   font-family: Arial, sans-serif;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import WebhookPage from './pages/WebhookPage';
 import ApiTesterPage from './pages/ApiTesterPage';
 import EndpointPage from './pages/EndpointPage';
 import RequestPage from './pages/RequestPage';
+import '@bigbinary/neetoui/dist/index.css';
 import './index.scss';
 import { ToastContainer } from 'react-toastify';
 


### PR DESCRIPTION
## Summary
- import NeetoUI styles directly in React entry
- adjust global stylesheet

## Testing
- `yarn install --mode=skip-build`
- `nohup yarn dev --port 5173 --host 0.0.0.0 >/tmp/vite.log 2>&1 &`
- `curl -I 127.0.0.1:5174`

------
https://chatgpt.com/codex/tasks/task_e_686e5ef5f794832c91273c071c13375e