### PR TITLE
Add SiteHeader and restore navigation links

### DIFF
--- a/frontend/src/components/SiteHeader.tsx
+++ b/frontend/src/components/SiteHeader.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+
+const SiteHeader: React.FC = () => {
+  const navigate = useNavigate();
+
+  const createEndpoint = async () => {
+    try {
+      const res = await fetch('/api/endpoints', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ expires_at: null })
+      });
+      if (!res.ok) throw new Error('Failed to create endpoint');
+      const data = await res.json();
+      if (!data.uuid) throw new Error('Invalid response');
+      navigate(`/endpoint/${data.uuid}`);
+    } catch (err) {
+      alert('Failed to create endpoint. Is the backend running?');
+    }
+  };
+
+  return (
+    <header className="site-header">
+      <div className="site-logo">Webhook Mirror</div>
+      <div className="nav-links">
+        <button className="start-btn" onClick={createEndpoint}>Start Testing</button>
+        <Link to="/dashboard" className="btn">Dashboard</Link>
+        <Link to="/api-test" className="btn">API Tester</Link>
+      </div>
+    </header>
+  );
+};
+
+export default SiteHeader;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -38,6 +38,42 @@ body {
 .btn:hover {
   background-color: #1d4ed8;
 }
+.site-header {
+  width: 100%;
+  background: #ffffff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+.site-logo {
+  font-weight: bold;
+  font-size: 1.25rem;
+}
+.nav-links {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+.start-btn {
+  background: #22C55E;
+  color: #ffffff;
+  border: none;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: background 0.2s, transform 0.1s;
+}
+.start-btn:hover {
+  background: #16a34a;
+}
+.start-btn:active {
+  transform: translateY(1px);
+}
+
 
 .url-box {
   width: 100%;

--- a/frontend/src/pages/ApiTesterPage.tsx
+++ b/frontend/src/pages/ApiTesterPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import SiteHeader from '../components/SiteHeader';
 
 const ApiTesterPage: React.FC = () => {
   const [testUrl, setTestUrl] = useState('');
@@ -44,6 +45,7 @@ const ApiTesterPage: React.FC = () => {
 
   return (
     <div className="container">
+      <SiteHeader />
       <h1 className="header">API Tester</h1>
       <p className="mb-4">Send HTTP requests to quickly inspect status, headers, and body.</p>
       <input
@@ -85,7 +87,6 @@ const ApiTesterPage: React.FC = () => {
       />
       <div className="mb-2">
         <button onClick={testApi} className="btn mr-2">Send Request</button>
-        <Link to="/" className="btn">Back to home</Link>
       </div>
       {testResult && (
         <div className="status mt-2">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
+import SiteHeader from '../components/SiteHeader';
 
 interface Endpoint {
   id: number;
@@ -92,10 +93,8 @@ const DashboardPage: React.FC = () => {
 
   return (
     <div className="container">
+      <SiteHeader />
       <h1 className="header">Dashboard</h1>
-      <div className="mb-2 text-sm">
-        <Link to="/" className="btn">Back to home</Link>
-      </div>
       {error && <p className="text-red-500 mb-2">{error}</p>}
       <div className="mb-4 flex" style={{gap: '0.5rem', alignItems: 'center'}}>
         <div className="text-left">

--- a/frontend/src/pages/EndpointPage.tsx
+++ b/frontend/src/pages/EndpointPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
+import SiteHeader from '../components/SiteHeader';
 import RequestList from '../components/RequestList';
 import { Req } from '../components/RequestListItem';
 import RequestInspector from '../components/RequestInspector';
@@ -45,10 +46,8 @@ const EndpointPage: React.FC = () => {
 
   return (
     <div className="container" style={{maxWidth: '1200px'}}>
+      <SiteHeader />
       <h1 className="header">Endpoint {uuid} <LiveIndicator /></h1>
-      <div className="mb-2 text-left">
-        <Link to="/" className="btn">Back to home</Link>
-      </div>
       <div className="flex" style={{gap: '1rem', alignItems: 'flex-start'}}>
         <div style={{flex: '1'}}>
           <div className="mb-2 flex" style={{gap: '0.5rem', alignItems: 'center'}}>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import SiteHeader from '../components/SiteHeader';
 
 const Home = () => {
   const navigate = useNavigate();
@@ -31,19 +32,6 @@ const Home = () => {
           background: #f9fafb;
           color: #1f2937;
         }
-        .home-header {
-          width: 100%;
-          background: #ffffff;
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          padding: 1rem 2rem;
-          box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-        }
-        .logo {
-          font-weight: bold;
-          font-size: 1.25rem;
-        }
         .hero {
           text-align: center;
           padding: 3rem 1rem;
@@ -65,7 +53,7 @@ const Home = () => {
           max-width: 600px;
           margin-bottom: 2rem;
         }
-        .cta, .start-btn {
+        .cta {
           background: #22C55E;
           color: #ffffff;
           border: none;
@@ -76,7 +64,7 @@ const Home = () => {
           box-shadow: 0 2px 4px rgba(0,0,0,0.1);
           transition: background 0.2s, transform 0.1s;
         }
-        .cta:hover, .start-btn:hover { background: #16a34a; }
+        .cta:hover { background: #16a34a; }
         .cta:active { transform: translateY(1px); }
         .features {
           display: flex;
@@ -94,15 +82,18 @@ const Home = () => {
           min-width: 120px;
           text-align: center;
         }
+        .actions {
+          padding-bottom: 2rem;
+          display: flex;
+          gap: 0.75rem;
+          justify-content: center;
+        }
         @media (min-width: 768px) {
           .hero h1 { font-size: 3rem; }
           .subtext { font-size: 1.25rem; }
         }
       `}</style>
-      <header className="home-header">
-        <div className="logo">Webhook Mirror</div>
-        <button className="start-btn" onClick={createEndpoint}>Start Testing</button>
-      </header>
+      <SiteHeader />
       <main className="hero">
         <h1>Debug webhooks <span>effortlessly</span></h1>
         <p className="subtext">Spin up a session-based URL and watch your requests arrive in real time.</p>
@@ -113,6 +104,10 @@ const Home = () => {
         <div className="feature">100% Free</div>
         <div className="feature">Real-time</div>
       </section>
+      <div className="actions">
+        <Link to="/dashboard" className="btn">Dashboard</Link>
+        <Link to="/api-test" className="btn">API Tester</Link>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/RequestPage.tsx
+++ b/frontend/src/pages/RequestPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { JSONTree } from 'react-json-tree';
 import { useParams } from 'react-router-dom';
+import SiteHeader from '../components/SiteHeader';
 
 interface Req {
   id: number;
@@ -50,6 +51,7 @@ const RequestPage: React.FC = () => {
 
   return (
     <div className="container">
+      <SiteHeader />
       <div className="space-y-4">
         <h1 className="header">Request {request.id}</h1>
         <div className="option-card text-left">

--- a/frontend/src/pages/WebhookPage.tsx
+++ b/frontend/src/pages/WebhookPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import SiteHeader from '../components/SiteHeader';
 
 interface Req {
   id: number;
@@ -71,6 +72,7 @@ const WebhookPage: React.FC = () => {
 
   return (
     <div className="container">
+      <SiteHeader />
       <h1 className="header">Webhook Mirror</h1>
       <p className="mb-4">WebhookMirror lets you capture and inspect HTTP requests. Generate a unique URL below and send your webhooks to it.</p>
       <textarea


### PR DESCRIPTION
## Summary
- create reusable `SiteHeader` component
- move header styles to global CSS
- show dashboard & API tester buttons on home
- apply new header on all pages

## Testing
- `yarn --cwd frontend build`


------
https://chatgpt.com/codex/tasks/task_e_686e78443af4832c81e87867602d1b46