### PR TITLE
Add heading next to logo in header

### DIFF
--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
   <circle cx="50" cy="50" r="45" fill="#10B981"/>
   <path d="M30 50 L45 65 L70 35" stroke="white" stroke-width="8" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <polygon points="50,20 80,80 20,80" fill="white" opacity="0.4"/>
 </svg>

--- a/frontend/src/components/SiteHeader.tsx
+++ b/frontend/src/components/SiteHeader.tsx
@@ -24,6 +24,7 @@ const SiteHeader: React.FC = () => {
     <header className="site-header">
       <Link to="/" className="site-logo" title="WebhookMirror home">
         <img src="/logo.svg" alt="WebhookMirror logo" className="logo-img" />
+        <span className="logo-text">Webhook Mirror</span>
       </Link>
       <div className="nav-links">
         <Link to="/" className="btn">Home</Link>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -65,11 +65,21 @@ body {
   box-sizing: border-box;
 }
 .site-logo {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: inherit;
 }
 
 .logo-img {
   height: 32px;
+}
+
+.logo-text {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1f2937;
 }
 .nav-links {
   display: flex;


### PR DESCRIPTION
## Summary
- tweak header to show logo and `Webhook Mirror` title
- style header text next to the logo
- update the site logo with a triangle accent

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e81c904ac832cb0c0e54c82e90948