### PR TITLE
UI: replace endpoint action buttons with dropdown menu

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -360,6 +360,41 @@ button:disabled {
   display: block;
 }
 
+.actions-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.actions-menu {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  margin-top: 0.25rem;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  z-index: 50;
+}
+
+.actions-menu button {
+  background: none;
+  border: none;
+  padding: 0.5rem 1rem;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+}
+
+.actions-menu button:hover:not(:disabled) {
+  background: #f3f4f6;
+}
+
 .json-tree {
   text-align: left;
   font-family: monospace;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -17,6 +17,7 @@ const DashboardPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [expiresAt, setExpiresAt] = useState('');
+  const [openMenuId, setOpenMenuId] = useState<number | null>(null);
 
   const loadEndpoints = async () => {
     setLoading(true);
@@ -79,6 +80,11 @@ const DashboardPage: React.FC = () => {
       body: JSON.stringify({ disabled })
     });
     loadEndpoints();
+    setOpenMenuId(null);
+  };
+
+  const toggleMenu = (id: number) => {
+    setOpenMenuId(prev => (prev === id ? null : id));
   };
 
   const deleteEndpoint = async (id: number) => {
@@ -89,6 +95,7 @@ const DashboardPage: React.FC = () => {
       alert(data.error || 'Failed to delete endpoint');
     }
     loadEndpoints();
+    setOpenMenuId(null);
   };
 
   return (
@@ -123,16 +130,21 @@ const DashboardPage: React.FC = () => {
                 <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
                 <td>{new Date(e.created_at).toLocaleString()}</td>
                 <td>{e.expires_at ? new Date(e.expires_at).toLocaleString() : 'None'}</td>
-                <td>
-                  <button className="btn mr-1" onClick={() => toggleDisabled(e.id, !e.disabled)}>
-                    {e.disabled ? 'Enable' : 'Disable'}
-                  </button>
-                  <button className="btn" disabled={!e.can_delete} onClick={() => deleteEndpoint(e.id)}>Delete</button>
-                  {!e.can_delete && (
-                    <span className="help-icon">
-                      ?
-                      <span className="tooltip">{e.delete_reason}</span>
-                    </span>
+                <td style={{ position: 'relative' }}>
+                  <button className="actions-toggle" onClick={() => toggleMenu(e.id)}>⋮</button>
+                  {openMenuId === e.id && (
+                    <div className="actions-menu">
+                      <button onClick={() => toggleDisabled(e.id, !e.disabled)}>
+                        {e.disabled ? 'Enable' : 'Disable'}
+                      </button>
+                      <button
+                        disabled={!e.can_delete}
+                        title={!e.can_delete ? e.delete_reason || undefined : undefined}
+                        onClick={() => deleteEndpoint(e.id)}
+                      >
+                        Delete
+                      </button>
+                    </div>
                   )}
                 </td>
               </tr>
@@ -145,16 +157,21 @@ const DashboardPage: React.FC = () => {
                 <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
                 <td>{new Date(e.created_at).toLocaleString()}</td>
                 <td>{e.expires_at ? new Date(e.expires_at).toLocaleString() : 'None'}</td>
-                <td>
-                  <button className="btn mr-1" onClick={() => toggleDisabled(e.id, !e.disabled)}>
-                    {e.disabled ? 'Enable' : 'Disable'}
-                  </button>
-                  <button className="btn" disabled={!e.can_delete} onClick={() => deleteEndpoint(e.id)}>Delete</button>
-                  {!e.can_delete && (
-                    <span className="help-icon">
-                      ?
-                      <span className="tooltip">{e.delete_reason}</span>
-                    </span>
+                <td style={{ position: 'relative' }}>
+                  <button className="actions-toggle" onClick={() => toggleMenu(e.id)}>⋮</button>
+                  {openMenuId === e.id && (
+                    <div className="actions-menu">
+                      <button onClick={() => toggleDisabled(e.id, !e.disabled)}>
+                        {e.disabled ? 'Enable' : 'Disable'}
+                      </button>
+                      <button
+                        disabled={!e.can_delete}
+                        title={!e.can_delete ? e.delete_reason || undefined : undefined}
+                        onClick={() => deleteEndpoint(e.id)}
+                      >
+                        Delete
+                      </button>
+                    </div>
                   )}
                 </td>
               </tr>
@@ -167,16 +184,21 @@ const DashboardPage: React.FC = () => {
                 <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
                 <td>{new Date(e.created_at).toLocaleString()}</td>
                 <td>{e.expires_at ? new Date(e.expires_at).toLocaleString() : 'None'}</td>
-                <td>
-                  <button className="btn mr-1" onClick={() => toggleDisabled(e.id, !e.disabled)}>
-                    {e.disabled ? 'Enable' : 'Disable'}
-                  </button>
-                  <button className="btn" disabled={!e.can_delete} onClick={() => deleteEndpoint(e.id)}>Delete</button>
-                  {!e.can_delete && (
-                    <span className="help-icon">
-                      ?
-                      <span className="tooltip">{e.delete_reason}</span>
-                    </span>
+                <td style={{ position: 'relative' }}>
+                  <button className="actions-toggle" onClick={() => toggleMenu(e.id)}>⋮</button>
+                  {openMenuId === e.id && (
+                    <div className="actions-menu">
+                      <button onClick={() => toggleDisabled(e.id, !e.disabled)}>
+                        {e.disabled ? 'Enable' : 'Disable'}
+                      </button>
+                      <button
+                        disabled={!e.can_delete}
+                        title={!e.can_delete ? e.delete_reason || undefined : undefined}
+                        onClick={() => deleteEndpoint(e.id)}
+                      >
+                        Delete
+                      </button>
+                    </div>
                   )}
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- convert endpoint actions to a three-dot dropdown
- style dropdown menu and toggle button

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e91af58b4832cbad07c99e5f7ede4