### PR TITLE
Add pagination to dashboard table

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -418,3 +418,24 @@ button:disabled {
     position: relative;
   }
 }
+
+.pagination {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+}
+.pagination button {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #ccc;
+  background: #fff;
+  cursor: pointer;
+}
+.pagination button.active {
+  font-weight: bold;
+  background: #e5e7eb;
+}
+.pagination button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
- implement page-based navigation on Dashboard endpoints table
- show page numbers with previous/next buttons
- style pagination controls

## Testing
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9f732fc0832cad1ec662713c7182