### PR TITLE
Integrate frontend build with Rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ backend/vendor/bundle/
 backend/log/
 backend/tmp/
 
+# Frontend build output served by Rails
+backend/public/assets/
+backend/public/index.html
+backend/public/logo.svg
+
 # Frontend dependencies
 frontend/node_modules/
 frontend/dist/

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Refer to `workflow.md` for the ongoing development notes and checklist derived f
 
 ## Running the application
 
-The backend and frontend are developed separately. Ensure you have **Ruby** (version 3.0 or higher) and **Node.js** (version 18 or higher) installed on your machine.
+The backend and frontend are developed separately in development, but the production build runs from a single Rails server. Ensure you have **Ruby** (version 3.0 or higher) and **Node.js** (version 18 or higher) installed on your machine.
 
-### 1. Start the Rails API backend
+### 1. Start the Rails API backend (development)
 
 ```bash
 cd backend
@@ -26,7 +26,7 @@ bin/rails db:setup    # create and migrate the database
 bin/dev               # start the Rails server on http://localhost:3000
 ```
 
-### 2. Start the React frontend
+### 2. Start the React frontend (development)
 
 Open a new terminal and run:
 
@@ -37,6 +37,14 @@ npm run dev           # start Vite dev server on http://localhost:5173
 ```
 
 With both servers running you can browse to `http://localhost:5173` to use the application while it interacts with the Rails API running on port 3000.
+
+### Building and running the full stack
+
+To build the frontend and serve it via Rails on a single port run:
+
+```bash
+./start.sh
+```
 
 
 The UI follows [Neetix](https://neetix.neetokb.com/) best practices such as using sentence case and clear loading states.

--- a/backend/app/controllers/static_controller.rb
+++ b/backend/app/controllers/static_controller.rb
@@ -1,0 +1,5 @@
+class StaticController < ActionController::Base
+  def index
+    render file: Rails.root.join("public", "index.html"), layout: false
+  end
+end

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -14,6 +14,7 @@ Rails.application.configure do
 
   # Cache assets for far-future expiry since they are all digest stamped.
   config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
+  config.public_file_server.enabled = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -3,15 +3,16 @@ Rails.application.routes.draw do
     get "endpoints/by_uuid/:uuid", to: "endpoints#show_by_uuid"
     resources :endpoints, only: [ :create, :index, :update, :destroy ] do
       resources :requests, only: [ :index, :create ] do
-        delete '/', to: 'requests#destroy_all', on: :collection
+        delete "/", to: "requests#destroy_all", on: :collection
       end
     end
     resources :requests, only: [ :show ]
   end
 
-  match "/:uuid", to: "capture#receive", via: :all
+  match "/:uuid", to: "capture#receive", via: :all, constraints: { uuid: /[0-9a-fA-F\-]{36}/ }
 
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # root "posts#index"
+  root "static#index"
+  get "*path", to: "static#index"
 end

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  base: './',
+  build: {
+    outDir: '../backend/public',
+    emptyOutDir: true,
+  },
   server: {
     proxy: {
       '/api': 'http://localhost:3000',

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# Build frontend into Rails public folder
+cd frontend
+npm run build
+cd ../backend
+
+# Start Rails server
+bundle exec rails server


### PR DESCRIPTION
## Summary
- output Vite build into Rails `public` directory
- serve built files with new `StaticController`
- send unmatched routes to the SPA index
- enable static file serving in production
- add helper script to build and run the whole stack
- document combined setup

## Testing
- `npm --prefix frontend run build`
- `bundle exec rubocop`

------
https://chatgpt.com/codex/tasks/task_e_686ea16c0514832cbe6bcde9875917b9