### PR TITLE
Add request replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Refer to `workflow.md` for the ongoing development notes and checklist derived f
 ## Features
 
 - Sidebar navigation with quick access to **Start Testing**, **Dashboard** and **API Tester**
+- Request inspector with tabs for headers, body, query params and cookies
 - Export captured requests to JSON
 - Clear all requests for an endpoint
 - Copy any request as a cURL command
+- Replay captured requests to any target URL
 
 ## Running the application
 
@@ -85,3 +87,9 @@ Navigate to `/api-test` in the frontend to open the **API Tester**. Enter the in
 * After sending requests, open the generated endpoint page in your browser.
 * The list of captured requests appears. Click any entry to view full headers and body.
 * Use these details to debug your webhook integrations.
+
+### Replaying requests
+
+* While viewing a request in the inspector, click **Replay**.
+* Enter the target URL you want to send the captured request to.
+* The backend will resend the request and report the status code.

--- a/backend/app/controllers/api/requests_controller.rb
+++ b/backend/app/controllers/api/requests_controller.rb
@@ -1,6 +1,8 @@
+require 'net/http'
+
 class Api::RequestsController < ApplicationController
   before_action :set_endpoint, only: [ :index, :create, :destroy_all ]
-  before_action :set_request, only: [ :show ]
+  before_action :set_request, only: [ :show, :replay ]
 
   def index
     render json: @endpoint.requests.order(created_at: :desc)
@@ -8,6 +10,31 @@ class Api::RequestsController < ApplicationController
 
   def show
     render json: @request
+  end
+
+  def replay
+    target = params[:target_url]
+    return render(json: { error: 'target_url required' }, status: :bad_request) if target.blank?
+
+    headers = begin
+      JSON.parse(@request.headers)
+    rescue JSON::ParserError
+      {}
+    end
+
+    uri = URI.parse(target)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+    path = uri.path.empty? ? '/' : uri.path
+    path += "?#{uri.query}" if uri.query
+
+    req_class = Net::HTTP.const_get(@request.method.capitalize)
+    http_req = req_class.new(path)
+    headers.each { |k, v| http_req[k] = v unless k.to_s.downcase == 'host' }
+    http_req.body = @request.body if @request.body.present?
+    res = http.request(http_req)
+
+    render json: { status: res.code.to_i, headers: res.to_hash, body: res.body }
   end
 
   def create

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
         delete "/", to: "requests#destroy_all", on: :collection
       end
     end
-    resources :requests, only: [ :show ]
+    resources :requests, only: [ :show ] do
+      post :replay, on: :member
+    end
   end
 
   match "/:uuid", to: "capture#receive", via: :all, constraints: { uuid: /[0-9a-fA-F\-]{36}/ }

--- a/frontend/src/components/RequestInspector.tsx
+++ b/frontend/src/components/RequestInspector.tsx
@@ -37,6 +37,22 @@ const RequestInspector: React.FC<Props> = ({ request, endpointUuid }) => {
     alert('Copied as cURL');
   };
 
+  const replayRequest = async () => {
+    const target = window.prompt('Replay to URL:', `${window.location.origin}/${endpointUuid}`);
+    if (!target) return;
+    try {
+      const res = await fetch(`/api/requests/${request.id}/replay`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target_url: target })
+      });
+      const data = await res.json();
+      alert(`Replay status: ${data.status}`);
+    } catch {
+      alert('Replay failed');
+    }
+  };
+
   const parsedHeaders = useMemo(() => {
     if (typeof request.headers === 'string') {
       try {
@@ -60,7 +76,10 @@ const RequestInspector: React.FC<Props> = ({ request, endpointUuid }) => {
     <div className="inspector">
       <div className="flex justify-between mb-2">
         <h2 className="text-xl">Request {request.id}</h2>
-        <button className="btn" onClick={copyCurl}>Copy as cURL</button>
+        <div className="space-x-2">
+          <button className="btn" onClick={copyCurl}>Copy as cURL</button>
+          <button className="btn" onClick={replayRequest}>Replay</button>
+        </div>
       </div>
       <Tabs tabs={['Raw', 'Headers', 'Body', 'Query Params', 'Cookies']} active={active} onChange={setActive} />
       {active === 'Raw' && (


### PR DESCRIPTION
## Summary
- implement backend API to replay stored requests
- add Replay button in React inspector
- document the new feature

## Testing
- `bundle exec rails test`
- `yarn build` *(fails: cannot resolve `ramda`)*

------
https://chatgpt.com/codex/tasks/task_e_686eafb74e10832c8a66bd6bbfd9e49a