### PR TITLE
Update dashboard and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ Refer to `workflow.md` for the ongoing development notes and checklist derived f
 - Clear all requests for an endpoint
 - Copy any request as a cURL command
 
+## How it works
+
+1. Create a new endpoint from the homepage.
+2. Send HTTP requests to that endpoint using your service or `curl`.
+3. Inspect the captured requests in the dashboard.
+
+### Example curl command
+
+```bash
+curl -X POST http://localhost:3000/<endpoint-id> \
+     -H "Content-Type: application/json" \
+     -d '{"hello":"world"}'
+```
+
 ## Running the application
 
 The backend and frontend are developed separately in development, but the production build runs from a single Rails server. Ensure you have **Ruby** (version 3.0 or higher) and **Node.js** (version 18 or higher) installed on your machine.

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -99,20 +99,20 @@ const DashboardPage: React.FC = () => {
         <>
         <table className="w-full text-left table">
           <thead>
-            <tr><th>UUID</th><th>Created</th><th>Expires</th><th>Actions</th></tr>
+            <tr><th>UUID</th><th>Created</th><th>Expires</th></tr>
           </thead>
           <tbody>
             {pagedEndpoints.map((e, idx) => (
               <React.Fragment key={e.id}>
                 {(idx === 0 || pagedEndpoints[idx - 1].group !== e.group) && (
-                  <tr><th colSpan={4} className="group-header">{e.group}</th></tr>
+                  <tr><th colSpan={3} className="group-header">{e.group}</th></tr>
                 )}
                 <tr className="endpoint-row">
-                  <td><Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link></td>
-                  <td>{new Date(e.created_at).toLocaleString()}</td>
-                  <td>{e.expires_at ? new Date(e.expires_at).toLocaleString() : 'None'}</td>
                   <td style={{ position: 'relative' }}>
-                    <button className="actions-toggle" onClick={() => toggleMenu(e.id)}>⋮</button>
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                      <Link to={`/endpoint/${e.uuid}`}>{e.uuid}</Link>
+                      <button className="actions-toggle" onClick={() => toggleMenu(e.id)}>⋮</button>
+                    </div>
                     {openMenuId === e.id && (
                       <div className="actions-menu">
                         <button onClick={() => toggleDisabled(e.id, !e.disabled)}>
@@ -132,6 +132,8 @@ const DashboardPage: React.FC = () => {
                       </div>
                     )}
                   </td>
+                  <td>{new Date(e.created_at).toLocaleString()}</td>
+                  <td>{e.expires_at ? new Date(e.expires_at).toLocaleString() : 'None'}</td>
                 </tr>
               </React.Fragment>
             ))}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -104,6 +104,23 @@ const Home = () => {
         <div className="feature">100% Free</div>
         <div className="feature">Real-time</div>
       </section>
+      <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
+        <p style={{ marginBottom: '0.5rem' }}>Example curl command:</p>
+        <pre className="code-box" style={{ display: 'inline-block', textAlign: 'left' }}>{`curl -X POST http://localhost:3000/<endpoint-id> -H "Content-Type: application/json" -d '{"hello":"world"}'`}</pre>
+      </div>
+      <h2 style={{ textAlign: 'center', fontSize: '1.25rem', fontWeight: 600, marginBottom: '0.5rem' }}>Features</h2>
+      <ul style={{ textAlign: 'left', maxWidth: '600px', margin: '0 auto 1.5rem', listStyle: 'disc inside' }}>
+        <li>Sidebar navigation with quick access to Start Testing, Dashboard and API Tester</li>
+        <li>Export captured requests to JSON</li>
+        <li>Clear all requests for an endpoint</li>
+        <li>Copy any request as a cURL command</li>
+      </ul>
+      <h2 style={{ textAlign: 'center', fontSize: '1.25rem', fontWeight: 600, marginBottom: '0.5rem' }}>How it works</h2>
+      <ol style={{ textAlign: 'left', maxWidth: '600px', margin: '0 auto', listStyle: 'decimal inside' }}>
+        <li>Create a unique endpoint using the Start Testing button</li>
+        <li>Send HTTP requests from your service or via curl</li>
+        <li>Inspect the requests here in real time</li>
+      </ol>
     </div>
     </SidebarLayout>
   );


### PR DESCRIPTION
## Summary
- move endpoint actions dropdown inside the endpoint cell
- display example curl command, features list and how it works on the home page
- document a how it works section and example curl command in README

## Testing
- `npm run build` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686f45145a98832cbd8930a031c156be