### PR TITLE
Refine navigation and clean up landing page

### DIFF
--- a/frontend/src/components/SidebarLayout.tsx
+++ b/frontend/src/components/SidebarLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { NavLink, Link } from 'react-router-dom';
 
 interface Props {
   children: React.ReactNode;
@@ -16,10 +16,10 @@ const SidebarLayout: React.FC<Props> = ({ children }) => {
             <span className="logo-text">Webhook Mirror</span>
           </Link>
         </div>
-        <Link to="/webhook" className="nav-item">Start Testing</Link>
-        <Link to="/" className="nav-item">Home</Link>
-        <Link to="/dashboard" className="nav-item">Dashboard</Link>
-        <Link to="/api-test" className="nav-item">API Tester</Link>
+        <NavLink to="/webhook" className={({isActive}) => 'nav-item' + (isActive ? ' active' : '')}>Start Testing</NavLink>
+        <NavLink to="/" className={({isActive}) => 'nav-item' + (isActive ? ' active' : '')}>Home</NavLink>
+        <NavLink to="/dashboard" className={({isActive}) => 'nav-item' + (isActive ? ' active' : '')}>Dashboard</NavLink>
+        <NavLink to="/api-test" className={({isActive}) => 'nav-item' + (isActive ? ' active' : '')}>API Tester</NavLink>
       </div>
       <div className="main-content">
         {children}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -236,14 +236,13 @@ button:disabled {
 
 .nav-item {
   padding: 0.5rem;
-  margin-bottom: 0;
-  border-radius: 0;
+  margin-bottom: 0.75rem;
+  border-radius: 4px;
   text-decoration: none;
   display: block;
   font-weight: 600;
   color: #374151;
   transition: background 0.2s;
-  border-bottom: 1px solid #e5e7eb;
 }
 .nav-item:hover {
   background: #f3f4f6;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,33 +1,7 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import SidebarLayout from '../components/SidebarLayout';
 
 const Home = () => {
-  const navigate = useNavigate();
-  const [existingUuid, setExistingUuid] = React.useState('');
-  const [expiresAt, setExpiresAt] = React.useState('');
-
-  const createEndpoint = async () => {
-    try {
-      const res = await fetch('/api/endpoints', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ expires_at: expiresAt || null })
-      });
-      if (!res.ok) throw new Error('Failed to create endpoint');
-      const data = await res.json();
-      if (!data.uuid) throw new Error('Invalid response');
-      navigate(`/endpoint/${data.uuid}`);
-    } catch (err) {
-      alert('Failed to create endpoint. Is the backend running?');
-    }
-  };
-
-  const openExistingEndpoint = () => {
-    if (existingUuid.trim()) {
-      navigate(`/endpoint/${existingUuid.trim()}`);
-    }
-  };
 
   return (
     <SidebarLayout>
@@ -119,28 +93,7 @@ const Home = () => {
       <main className="hero">
         <h1>Debug webhooks <span>effortlessly</span></h1>
         <p className="subtext">Spin up a session-based URL and watch your requests arrive in real time.</p>
-        <div className="actions" style={{ marginBottom: '1rem' }}>
-          <input
-            type="text"
-            className="url-box"
-            style={{ width: '220px' }}
-            value={existingUuid}
-            onChange={e => setExistingUuid(e.target.value)}
-            placeholder="Existing endpoint ID"
-          />
-          <button className="cta" onClick={openExistingEndpoint}>Open</button>
-        </div>
-        <div className="actions">
-          <input
-            type="datetime-local"
-            className="url-box"
-            style={{ width: '220px' }}
-            value={expiresAt}
-            onChange={e => setExpiresAt(e.target.value)}
-            placeholder="Expiry (optional)"
-          />
-          <button className="cta" onClick={createEndpoint}>Create Endpoint</button>
-        </div>
+        {/* Removed endpoint creation controls */}
       </main>
       <section className="features">
         <div className="feature">Instant</div>
@@ -160,7 +113,7 @@ const Home = () => {
       </div>
       <h2 style={{ textAlign: 'center', fontSize: '1.25rem', fontWeight: 600, marginBottom: '0.5rem' }}>How it works</h2>
       <div className="info-grid">
-        <div className="info-item">1. Create a unique endpoint using the form above</div>
+        <div className="info-item">1. Create a unique endpoint from the Start Testing page</div>
         <div className="info-item">2. Send HTTP requests from your service or via curl</div>
         <div className="info-item">3. Inspect the requests here in real time</div>
       </div>

--- a/frontend/src/pages/WebhookPage.tsx
+++ b/frontend/src/pages/WebhookPage.tsx
@@ -66,6 +66,12 @@ const WebhookPage: React.FC = () => {
     }
   };
 
+  const openEndpoint = () => {
+    if (endpointUrl) {
+      window.open(endpointUrl, '_blank');
+    }
+  };
+
   const loadRequests = async () => {
     if (!endpointId) return;
     const res = await fetch(`/api/endpoints/${endpointId}/requests`);
@@ -103,9 +109,9 @@ const WebhookPage: React.FC = () => {
       />
       {endpointUrl && (
         <div className="link-box">
-          <a href={endpointUrl} target="_blank" rel="noopener noreferrer">
+          <button onClick={openEndpoint} className="btn">
             Open endpoint
-          </a>
+          </button>
         </div>
       )}
       {captureUrl && (


### PR DESCRIPTION
## Summary
- remove endpoint controls from landing page
- switch sidebar links to `NavLink` and increase spacing
- turn "Open endpoint" link into a button
- small CSS tweaks to highlight sidebar selection

## Testing
- `yarn build` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686f4943b410832ca00c80eb12df825f