### PR TITLE
UI refresh for home and start testing pages

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,7 +1,14 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import SidebarLayout from '../components/SidebarLayout';
 
 const Home = () => {
+  const [showMore, setShowMore] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => setShowMore(true);
+    window.addEventListener('scroll', handleScroll, { once: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
 
   return (
     <SidebarLayout>
@@ -52,18 +59,17 @@ const Home = () => {
         .features {
           display: flex;
           justify-content: center;
-          gap: 1.5rem;
-          padding: 2rem 1rem 3rem;
+          gap: 0.75rem;
+          padding: 1rem;
           flex-wrap: wrap;
         }
         .feature {
-          background: #ffffff;
-          padding: 1rem 2rem;
-          border-radius: 8px;
-          box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+          background: #22C55E;
+          color: #fff;
+          padding: 0.5rem 1rem;
+          border-radius: 9999px;
           font-weight: 600;
-          min-width: 120px;
-          text-align: center;
+          font-size: 0.875rem;
         }
         .actions {
           padding-bottom: 2rem;
@@ -110,23 +116,27 @@ const Home = () => {
         <div className="feature">Open source</div>
         <div className="feature">Session-based</div>
       </section>
-      <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
-        <p style={{ marginBottom: '0.5rem' }}>Example curl command:</p>
-        <pre className="code-box" style={{ display: 'inline-block', textAlign: 'left' }}>{`curl -X POST http://localhost:3000/<endpoint-id> -H "Content-Type: application/json" -d '{"hello":"world"}'`}</pre>
-      </div>
-      <h2 className="section-title">Features</h2>
-      <div className="info-grid">
-        <div className="info-item">Sidebar navigation with quick access to Start Testing, Dashboard and API Tester</div>
-        <div className="info-item">Export captured requests to JSON</div>
-        <div className="info-item">Clear all requests for an endpoint</div>
-        <div className="info-item">Copy any request as a cURL command</div>
-      </div>
-      <h2 className="section-title">How it works</h2>
-      <div className="info-grid">
-        <div className="info-item">1. Create a unique endpoint from the Start Testing page</div>
-        <div className="info-item">2. Send HTTP requests from your service or via curl</div>
-        <div className="info-item">3. Inspect the requests here in real time</div>
-      </div>
+      {showMore && (
+        <>
+        <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
+          <p style={{ marginBottom: '0.5rem' }}>Example curl command:</p>
+          <pre className="code-box" style={{ display: 'inline-block', textAlign: 'left' }}>{`curl -X POST http://localhost:3000/<endpoint-id> -H "Content-Type: application/json" -d '{"hello":"world"}'`}</pre>
+        </div>
+        <h2 className="section-title">Features</h2>
+        <div className="info-grid">
+          <div className="info-item">Sidebar navigation with quick access to Start Testing, Dashboard and API Tester</div>
+          <div className="info-item">Export captured requests to JSON</div>
+          <div className="info-item">Clear all requests for an endpoint</div>
+          <div className="info-item">Copy any request as a cURL command</div>
+        </div>
+        <h2 className="section-title">How it works</h2>
+        <div className="info-grid">
+          <div className="info-item">1. Create a unique endpoint from the Start Testing page</div>
+          <div className="info-item">2. Send HTTP requests from your service or via curl</div>
+          <div className="info-item">3. Inspect the requests here in real time</div>
+        </div>
+        </>
+      )}
     </div>
     </SidebarLayout>
   );

--- a/frontend/src/pages/WebhookPage.tsx
+++ b/frontend/src/pages/WebhookPage.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import SidebarLayout from '../components/SidebarLayout';
 
 interface Req {
@@ -11,7 +10,6 @@ interface Req {
 }
 
 const WebhookPage: React.FC = () => {
-  const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [endpointUrl, setEndpointUrl] = useState('');
   const [captureUrl, setCaptureUrl] = useState('');
@@ -19,29 +17,33 @@ const WebhookPage: React.FC = () => {
   const [endpointId, setEndpointId] = useState<number | null>(null);
   const [requests, setRequests] = useState<Req[]>([]);
   const [expiresAt, setExpiresAt] = useState('');
-  const [existingUuid, setExistingUuid] = useState('');
+  const [uuidInput, setUuidInput] = useState('');
+  const [loaded, setLoaded] = useState(false);
 
   const [apiStatus, setApiStatus] = useState<string | null>(null);
   const [apiHeaders, setApiHeaders] = useState<Record<string, string> | null>(null);
 
 
-  const createEndpoint = async () => {
+  const handleOpen = async () => {
     setLoading(true);
     setApiStatus(null);
     setApiHeaders(null);
     try {
-      const res = await fetch('/api/endpoints', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ expires_at: expiresAt || null })
-      });
-      if (!res.ok) throw new Error('Failed to create endpoint');
+      let res: Response;
+      if (uuidInput.trim()) {
+        res = await fetch(`/api/endpoints/by_uuid/${uuidInput.trim()}`);
+      } else {
+        res = await fetch('/api/endpoints', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ expires_at: expiresAt || null })
+        });
+      }
+      if (!res.ok) throw new Error('Failed to load endpoint');
       const data = await res.json();
       const { protocol, hostname, origin } = window.location;
-      // Display URLs should use the current origin (5173 when running locally)
       setCaptureUrl(`${origin}/${data.uuid}`);
       setEndpointUrl(`${origin}/endpoint/${data.uuid}`);
-      // Curl commands hit the Rails API on port 3000 during development
       const curlBase = hostname === 'localhost'
         ? `${protocol}//${hostname}:3000`
         : origin;
@@ -49,20 +51,14 @@ const WebhookPage: React.FC = () => {
       setEndpointId(data.id);
       setApiStatus(`Success: ${res.status}`);
       const headersObj: Record<string, string> = {};
-      res.headers.forEach((v, k) => {
-        headersObj[k] = v;
-      });
+      res.headers.forEach((v, k) => { headersObj[k] = v; });
       setApiHeaders(headersObj);
+      setUuidInput(data.uuid);
+      setLoaded(true);
     } catch (err) {
-      setApiStatus('Error creating endpoint');
+      setApiStatus('Error loading endpoint');
     } finally {
       setLoading(false);
-    }
-  };
-
-  const openExisting = () => {
-    if (existingUuid.trim()) {
-      navigate(`/endpoint/${existingUuid.trim()}`);
     }
   };
 
@@ -88,57 +84,59 @@ const WebhookPage: React.FC = () => {
   return (
     <SidebarLayout>
     <div className="container">
-      <h1 className="header">Webhook Mirror</h1>
-      <p className="mb-4">WebhookMirror lets you capture and inspect HTTP requests. Generate a unique URL below and send your webhooks to it.</p>
-      <div className="mb-2 flex" style={{gap: '0.5rem', alignItems: 'center'}}>
+      <h1 className="header">Start Testing</h1>
+      <p className="mb-4">Enter an existing endpoint ID or leave blank to create a new one.</p>
+      <div className="mb-4 flex" style={{gap: '0.5rem', alignItems: 'flex-end', justifyContent: 'center'}}>
         <input
           type="text"
           className="url-box"
           style={{ width: '220px' }}
-          value={existingUuid}
-          onChange={e => setExistingUuid(e.target.value)}
-          placeholder="Existing endpoint ID"
+          value={uuidInput}
+          onChange={e => setUuidInput(e.target.value)}
+          placeholder="Endpoint ID (optional)"
         />
-        <button onClick={openExisting} className="btn">Open</button>
+        <button onClick={handleOpen} disabled={loading} className="btn">
+          {loading ? 'Loading...' : 'Open endpoint'}
+        </button>
       </div>
-      <textarea
-        className="url-box"
-        readOnly
-        value={captureUrl}
-        placeholder="Click 'Generate URL' to create an endpoint"
-      />
-      {endpointUrl && (
-        <div className="link-box">
-          <button onClick={openEndpoint} className="btn">
-            Open endpoint
-          </button>
-        </div>
-      )}
-      {captureUrl && (
-        <div className="curl-examples">
+      {loaded && (
+        <>
+        <textarea
+          className="url-box"
+          readOnly
+          value={captureUrl}
+          placeholder="Endpoint URL will appear here"
+        />
+        {endpointUrl && (
+          <div className="link-box mb-4">
+            <button onClick={openEndpoint} className="btn">Open endpoint</button>
+          </div>
+        )}
+        <div className="curl-examples mb-4">
           <p className="font-semibold">Example curl POST request</p>
-          <pre className="code-box">{`curl -X POST ${curlUrl} -H "Content-Type: application/json" -d '{"hello":"world"}'`}</pre>
+          <pre className="code-box">{`curl -X POST ${curlUrl} -H \"Content-Type: application/json\" -d '{"hello":"world"}'`}</pre>
           <p className="font-semibold mt-2">Example curl GET request</p>
           <pre className="code-box">{`curl ${curlUrl}`}</pre>
         </div>
-      )}
-      <div className="mb-2 flex" style={{gap: '0.5rem', alignItems: 'center'}}>
-        <div className="text-left">
-          <label className="block mb-1">Select expiry time</label>
-          <input
-            type="datetime-local"
-            className="url-box"
-            value={expiresAt}
-            onChange={e => setExpiresAt(e.target.value)}
-            placeholder="Expiry (optional)"
-          />
+        <div className="mb-4 flex" style={{gap: '0.5rem', alignItems: 'center', justifyContent: 'center'}}>
+          <div className="text-left">
+            <label className="block mb-1">Select expiry time</label>
+            <input
+              type="datetime-local"
+              className="url-box"
+              value={expiresAt}
+              onChange={e => setExpiresAt(e.target.value)}
+              placeholder="Expiry (optional)"
+            />
+          </div>
+          <button onClick={handleOpen} disabled={loading} className="btn">
+            {loading ? 'Generating...' : 'Generate new URL'}
+          </button>
         </div>
-        <button onClick={createEndpoint} disabled={loading} className="btn">
-          {loading && <span className="loading-spinner" />} {loading ? 'Creating...' : 'Generate URL'}
-        </button>
-      </div>
-      {apiStatus && (
-        <div className="status">
+        </>
+      )}
+      {loaded && apiStatus && (
+        <div className="status mb-4">
           <p>{apiStatus}</p>
           {apiHeaders && (
             <pre className="headers">{JSON.stringify(apiHeaders, null, 2)}</pre>
@@ -146,7 +144,7 @@ const WebhookPage: React.FC = () => {
         </div>
       )}
       {endpointId && (
-        <div className="requests">
+        <div className="requests" style={{marginTop: '2rem'}}>
           <h2 className="header">Requests</h2>
           <button onClick={loadRequests} className="btn mb-2">Refresh</button>
           {requests.length === 0 ? (


### PR DESCRIPTION
## Summary
- update home layout to hide extra details until scroll
- simplify start testing flow with single open field
- show endpoint details after opening

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_686f565aa4a0832cb4ec6fbdf8613b6b