### PR TITLE
Fix deployment build and start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ To build the frontend and serve it via Rails on a single port run:
 ./start.sh
 ```
 
+When deploying to platforms like Heroku, the frontend is automatically built by
+the `heroku-postbuild` script defined in the repository root `package.json`. The
+`start.sh` script therefore only launches the Rails server in production
+environments.
+
 
 The UI follows [Neetix](https://neetix.neetokb.com/) best practices such as using sentence case and clear loading states.
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "webhookmirror-root",
+  "version": "1.0.0",
+  "private": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "heroku-postbuild": "npm --prefix frontend install && npm --prefix frontend run build"
+  }
+}

--- a/start.sh
+++ b/start.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# Build frontend into Rails public folder
-cd frontend
-npm run build
-cd ../backend
-
-# Start Rails server
+# Start Rails server from the backend directory.
+cd backend
 bundle exec rails server


### PR DESCRIPTION
## Summary
- ensure Node.js build step is run during deployment with a new `heroku-postbuild`
- simplify `start.sh` so runtime only starts the Rails server
- document automatic build behaviour in README

## Testing
- `bash -n start.sh`
- `node --version`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_686f5dc068e4832c83f63e60eea2367d