### PR TITLE
Install Bundler automatically in start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ To build the frontend and serve it via Rails on a single port run:
 ./start.sh
 ```
 
+The script checks for Bundler and the required Ruby gems. If they are missing
+they will be installed automatically before the Rails server starts.
+
 When deploying to platforms like Heroku, the frontend is automatically built by
 the `heroku-postbuild` script defined in the repository root `package.json`. The
 `start.sh` script therefore only launches the Rails server in production

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-# Start Rails server from the backend directory.
+# Ensure Bundler and gems are installed before starting the Rails server.
+if ! command -v bundle >/dev/null 2>&1; then
+  echo "Bundler not found; installing..."
+  gem install --no-document bundler
+fi
+
 cd backend
+
+# Install gems if they are missing
+bundle check || bundle install --jobs 4 --retry 3
+
 bundle exec rails server


### PR DESCRIPTION
## Summary
- install Bundler if missing when running `start.sh`
- ensure gems are installed before starting Rails
- document Bundler auto-installation in README

## Testing
- `bundle install --jobs 4 --retry 3`
- `bin/brakeman --no-pager`
- `bin/rubocop`

------
https://chatgpt.com/codex/tasks/task_e_686f601fd038832ca231360a7cfffb63